### PR TITLE
Allow auto-updating relative timestamps in the test data

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -1,3 +1,6 @@
+const path = require('path')
+const helpers = require(path.join(__dirname, '../../lib/helpers.js'))
+
 module.exports = {
   'cases': [
     {
@@ -146,8 +149,8 @@ module.exports = {
       'previousOrderStatus': 'Order ended 24 Nov 2016',
       'risk': 'Medium',
       'nextAppointment': {
-        'timestamp': '2021-04-23T13:00',
-        'endTime': '2021-04-23T14:00',
+        'timestamp': helpers.tomorrowAt('13:00'),
+        'endTime': helpers.tomorrowAt('14:00'),
         'type': 'Office visit'
       },
       'contactHistory': [

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,7 @@ const contactTypes = require(path.join(__dirname, '../app/data/contact-types.js'
 const { Locations } = require(path.join(__dirname, '../app/models/locations.js'))
 const { ArrangedSession } = require(path.join(__dirname, '../app/models/arranged-session.js'))
 const { RARCategories } = require(path.join(__dirname, '../app/models/rar-categories.js'))
+const { DateTime } = require('luxon')
 
 exports.progressPercentage = (progressInMonths, lengthInMonths) => {
   return progressInMonths * 1.0 * 100 / lengthInMonths
@@ -24,6 +25,18 @@ exports.possibleContactTypes = (providerCode) => {
 
 exports.possibleLocations = (providerCode, teamCodes) => {
   return Locations.forTeams(teamCodes)
+}
+
+exports.happeningIn = (params) => {
+  return DateTime.now().plus({days: params.daysLater}).toISODate() + 'T' + params.atTime
+}
+
+exports.todayAt = (time) => {
+  return exports.happeningIn({daysLater: 0, atTime: time})
+}
+
+exports.tomorrowAt = (time) => {
+  return exports.happeningIn({daysLater: 1, atTime: time})
 }
 
 exports.addHelpers = function (env) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,7 @@ const contactTypes = require(path.join(__dirname, '../app/data/contact-types.js'
 const { Locations } = require(path.join(__dirname, '../app/models/locations.js'))
 const { ArrangedSession } = require(path.join(__dirname, '../app/models/arranged-session.js'))
 const { RARCategories } = require(path.join(__dirname, '../app/models/rar-categories.js'))
-const { DateTime } = require('luxon')
+const { DateTime } = require('luxon-business-days')
 
 exports.progressPercentage = (progressInMonths, lengthInMonths) => {
   return progressInMonths * 1.0 * 100 / lengthInMonths
@@ -28,7 +28,7 @@ exports.possibleLocations = (providerCode, teamCodes) => {
 }
 
 exports.happeningIn = (params) => {
-  return DateTime.now().plus({days: params.daysLater}).toISODate() + 'T' + params.atTime
+  return DateTime.now().plusBusiness({days: params.daysLater}).toISODate() + 'T' + params.atTime
 }
 
 exports.todayAt = (time) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7677,6 +7677,11 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
       "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
+    "luxon-business-days": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/luxon-business-days/-/luxon-business-days-2.8.2.tgz",
+      "integrity": "sha512-j9CBauwWDzYlMmru+Dz4B1miXXv2uNrtW0NCOtharVGHiVscrXTWvi5alkZr89FN6fzfZ9oyghudTPiKNd9slw=="
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-sourcemaps": "^2.6.0",
     "keypather": "^3.0.0",
     "luxon": "^1.24.1",
+    "luxon-business-days": "^2.8.2",
     "marked": "^0.7.0",
     "notifications-node-client": "^4.1.0",
     "nunjucks": "^3.2.2",


### PR DESCRIPTION
## Context

User research participants notice it when test data dates are inconsistent (e.g. upcoming appointments are in the past). Previously we've had to [update test data prior to testing](https://github.com/ministryofjustice/hmpps-steel-thread/pull/97) to ensure believability.

## What

Introduce some helper functions which allow specifying a timestamp that's:

* today
* tomorrow
* `x` days in the future

This change also adds a `luxon` plugin called `luxon-business-days` which helps avoid appointment dates that fall on the weekends.