### PR TITLE
Use alternative office visit contact type

### DIFF
--- a/app/models/rar-categories.js
+++ b/app/models/rar-categories.js
@@ -22,7 +22,7 @@ class RARCategories {
       return this.providedContactTypeCode
     } else {
       const typeOfSessionToContactTypeCode = {
-        'Office visit': 'COAP',
+        'Office visit': 'APAT',
         'Home visit': 'CHVS',
         'Video call': 'COVC',
         'Phone call': 'COPT'

--- a/app/routes.js
+++ b/app/routes.js
@@ -12,7 +12,7 @@ router.get('/switch-provider/:newProvider', function (req, res) {
   req.session.data['provider-code'] = newProvider
   req.session.data['team-codes'] = req.session.data['default-teams'][newProvider]
 
-  res.redirect('/progress')
+  res.redirect('/cases')
 })
 
 module.exports = router


### PR DESCRIPTION
We weren't mapping to quite the right contact type before, and it wasn't possible to record RARs against the old one in all cases.