### PR TITLE
Tidying confirm attendance flow (part 5)

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -156,13 +156,15 @@ module.exports = [
       'endTime': helpers.yesterdayAt('14:00'),
       'type': 'Office visit',
       'countsTowardsRAR': true,
-      'RARCategory': 'Thinking skills, attitudes and behaviour'
+      'RARCategory': 'Thinking skills, attitudes and behaviour',
+      'sessionId': 456
     },
     'contactHistory': [
       {
         'type': 'Office visit',
         'probationPractitioner': 'Mark Berridge',
         'timestamp': helpers.yesterdayAt('13:00'),
+        'sessionId': 456,
         'outcome': null
       },
       {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -2,12 +2,14 @@ const path = require('path')
 const cases = require('./cases')
 const helpers = require(path.join(__dirname, '../../lib/helpers.js'))
 
-const confirmASessionDefaults = (map, su) => {
+const confirmAttendanceDefaults = (map, su) => {
   if (su.previousAppointment) {
-    map[su.CRN] = {
+    var defaults = {}
+    defaults[su.previousAppointment.sessionId] = {
       'countsTowardsRAR': su.previousAppointment.countsTowardsRAR ? 'Yes' : 'No',
       'RARCategory': su.previousAppointment.RARCategory
     }
+    map[su.CRN] = defaults
   }
   return map
 }
@@ -20,7 +22,7 @@ module.exports = {
   },
   'team-codes': ['C17ETE'],
   cases: cases,
-  'confirm-a-session': cases.reduce(confirmASessionDefaults, {}),
+  'confirm-attendance': cases.reduce(confirmAttendanceDefaults, {}),
   'arrange-a-session': {
     'J678910': {
       123: {

--- a/app/routes/confirm-attendance.js
+++ b/app/routes/confirm-attendance.js
@@ -1,39 +1,45 @@
 module.exports = router => {
-  router.get([
-    '/confirm-attendance/:CRN/:view'
+  router.all([
+    '/confirm-attendance/:CRN/:sessionId',
+    '/confirm-attendance/:CRN/:sessionId/:view'
   ], (req, res, next) => {
     const data = req.session.data
     res.locals.CRN = req.params.CRN
+    res.locals.sessionId = req.params.sessionId
     res.locals.case = data.cases.find(obj => {
       return obj.CRN === req.params.CRN
     })
     next()
   })
 
-  router.get('/confirm-attendance/:CRN/:view', function (req, res) {
+  router.get('/confirm-attendance/:CRN/:sessionId/:view', function (req, res) {
     res.render(`confirm-attendance/${req.params.view}`)
   })
 
-  router.post('/confirm-attendance/:CRN/notes', function (req, res) {
-    let shouldAddNotes = req.session.data['confirm-a-session'][req.params.CRN]['add-notes'] === 'Yes'
+  router.get('/confirm-attendance/:CRN/:sessionId', function (req, res) {
+    res.render('confirm-attendance/start')
+  })
+
+  router.post('/confirm-attendance/:CRN/:sessionId/notes', function (req, res) {
+    let shouldAddNotes = req.session.data['confirm-attendance'][req.params.CRN][req.params.sessionId]['add-notes'] === 'Yes'
 
     if (shouldAddNotes) {
-      res.redirect(`/confirm-attendance/${req.params.CRN}/notes`)
+      res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/notes`)
     } else {
-      res.redirect(`/confirm-attendance/${req.params.CRN}/check`)
+      res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/check`)
     }
   })
 
-  router.post('/confirm-attendance/:CRN/non-compliance-reason', function (req, res) {
-    switch (req.session.data['confirm-a-session'][req.params.CRN]['did-service-user-comply']) {
+  router.post('/confirm-attendance/:CRN/:sessionId/non-compliance-reason', function (req, res) {
+    switch (req.session.data['confirm-attendance'][req.params.CRN][req.params.sessionId]['did-service-user-comply']) {
       case 'Yes':
-        res.redirect(`/confirm-attendance/${req.params.CRN}/rar-categories`)
+        res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/rar-categories`)
         break;
       case 'No':
-        res.redirect(`/confirm-attendance/${req.params.CRN}/non-compliance-reason`)
+        res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/non-compliance-reason`)
         break;
       default:
-        res.redirect(`/confirm-attendance/${req.params.CRN}/absence-acceptable`)
+        res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/absence-acceptable`)
     }
   })
 }

--- a/app/routes/confirm-attendance.js
+++ b/app/routes/confirm-attendance.js
@@ -1,34 +1,39 @@
 module.exports = router => {
-  const CRN = 'J678910'
-
   router.get([
-    '/confirm-attendance/:view'
+    '/confirm-attendance/:CRN/:view'
   ], (req, res, next) => {
     const data = req.session.data
-    res.locals.CRN = CRN
+    res.locals.CRN = req.params.CRN
+    res.locals.case = data.cases.find(obj => {
+      return obj.CRN === req.params.CRN
+    })
     next()
   })
 
-  router.post('/confirm-attendance/notes', function (req, res) {
-    let shouldAddNotes = req.session.data['confirm-a-session'][CRN]['add-notes'] === 'Yes'
+  router.get('/confirm-attendance/:CRN/:view', function (req, res) {
+    res.render(`confirm-attendance/${req.params.view}`)
+  })
+
+  router.post('/confirm-attendance/:CRN/notes', function (req, res) {
+    let shouldAddNotes = req.session.data['confirm-a-session'][req.params.CRN]['add-notes'] === 'Yes'
 
     if (shouldAddNotes) {
-      res.redirect('/confirm-attendance/notes')
+      res.redirect(`/confirm-attendance/${req.params.CRN}/notes`)
     } else {
-      res.redirect('/confirm-attendance/check')
+      res.redirect(`/confirm-attendance/${req.params.CRN}/check`)
     }
   })
 
-  router.post('/confirm-attendance/non-compliance-reason', function (req, res) {
-    switch (req.session.data['confirm-a-session'][CRN]['did-service-user-comply']) {
+  router.post('/confirm-attendance/:CRN/non-compliance-reason', function (req, res) {
+    switch (req.session.data['confirm-a-session'][req.params.CRN]['did-service-user-comply']) {
       case 'Yes':
-        res.redirect('/confirm-attendance/rar-categories')
+        res.redirect(`/confirm-attendance/${req.params.CRN}/rar-categories`)
         break;
       case 'No':
-        res.redirect('/confirm-attendance/non-compliance-reason')
+        res.redirect(`/confirm-attendance/${req.params.CRN}/non-compliance-reason`)
         break;
       default:
-        res.redirect('/confirm-attendance/absence-acceptable')
+        res.redirect(`/confirm-attendance/${req.params.CRN}/absence-acceptable`)
     }
   })
 }

--- a/app/routes/confirm-attendance.js
+++ b/app/routes/confirm-attendance.js
@@ -1,3 +1,8 @@
+const {
+  confirmAttendanceWizardPaths,
+  confirmAttendanceWizardForks
+} = require('../utils/confirm-attendance-wizard-paths')
+
 module.exports = router => {
   router.all([
     '/confirm-attendance/:CRN/:sessionId',
@@ -13,33 +18,19 @@ module.exports = router => {
   })
 
   router.get('/confirm-attendance/:CRN/:sessionId/:view', function (req, res) {
-    res.render(`confirm-attendance/${req.params.view}`)
+    res.render(`confirm-attendance/${req.params.view}`, { paths: confirmAttendanceWizardPaths(req) })
   })
 
   router.get('/confirm-attendance/:CRN/:sessionId', function (req, res) {
-    res.render('confirm-attendance/start')
+    res.render('confirm-attendance/start', { paths: confirmAttendanceWizardPaths(req) })
   })
 
-  router.post('/confirm-attendance/:CRN/:sessionId/notes', function (req, res) {
-    let shouldAddNotes = req.session.data['confirm-attendance'][req.params.CRN][req.params.sessionId]['add-notes'] === 'Yes'
-
-    if (shouldAddNotes) {
-      res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/notes`)
-    } else {
-      res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/check`)
-    }
-  })
-
-  router.post('/confirm-attendance/:CRN/:sessionId/non-compliance-reason', function (req, res) {
-    switch (req.session.data['confirm-attendance'][req.params.CRN][req.params.sessionId]['did-service-user-comply']) {
-      case 'Yes':
-        res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/rar-categories`)
-        break;
-      case 'No':
-        res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/non-compliance-reason`)
-        break;
-      default:
-        res.redirect(`/confirm-attendance/${req.params.CRN}/${req.params.sessionId}/absence-acceptable`)
-    }
+  router.post([
+    '/confirm-attendance/:CRN/:sessionId',
+    '/confirm-attendance/:CRN/:sessionId/:view'
+  ], function (req, res) {
+    const fork = confirmAttendanceWizardForks(req)
+    const paths = confirmAttendanceWizardPaths(req)
+    fork ? res.redirect(fork) : res.redirect(paths.next)
   })
 }

--- a/app/utils/confirm-attendance-wizard-paths.js
+++ b/app/utils/confirm-attendance-wizard-paths.js
@@ -1,0 +1,40 @@
+const {
+  nextAndBackPaths,
+  nextForkPath
+} = require('../utils/wizard-helpers')
+
+function confirmAttendanceWizardPaths (req) {
+  const CRN = req.params.CRN
+  const sessionId = req.params.sessionId
+
+  var paths = [
+    `/cases/${CRN}/timeline`,
+    `/confirm-attendance/${CRN}/${sessionId}`,
+    `/confirm-attendance/${CRN}/${sessionId}/compliance`,
+    `/confirm-attendance/${CRN}/${sessionId}/non-compliance-reason`,
+    `/confirm-attendance/${CRN}/${sessionId}/absence-acceptable`,
+    `/confirm-attendance/${CRN}/${sessionId}/rar-categories`,
+    `/confirm-attendance/${CRN}/${sessionId}/add-notes`,
+    `/confirm-attendance/${CRN}/${sessionId}/notes`,
+    `/confirm-attendance/${CRN}/${sessionId}/check`,
+    `/confirm-attendance/${CRN}/${sessionId}/confirmation`,
+    `/arrange-a-session/${CRN}/start`
+  ]
+
+  return nextAndBackPaths(paths, req)
+}
+
+function confirmAttendanceWizardForks (req) {
+  const CRN = req.params.CRN
+  const sessionId = req.params.sessionId
+
+  var forks = [
+  ]
+
+  return nextForkPath(forks, req)
+}
+
+module.exports = {
+  confirmAttendanceWizardPaths,
+  confirmAttendanceWizardForks
+}

--- a/app/utils/confirm-attendance-wizard-paths.js
+++ b/app/utils/confirm-attendance-wizard-paths.js
@@ -29,6 +29,33 @@ function confirmAttendanceWizardForks (req) {
   const sessionId = req.params.sessionId
 
   var forks = [
+    {
+      currentPath: `/confirm-attendance/${CRN}/${sessionId}/compliance`,
+      storedData: ['confirm-attendance', CRN, sessionId, 'did-service-user-comply'],
+      excludedValues: [],
+      forkPath: (value) => {
+        switch (value) {
+          case 'Absent':
+            return `/confirm-attendance/${CRN}/${sessionId}/absence-acceptable`
+          case 'No':
+            return `/confirm-attendance/${CRN}/${sessionId}/non-compliance-reason`
+          default:
+            return `/confirm-attendance/${CRN}/${sessionId}/rar-categories`
+        }
+      }
+    },
+    {
+      currentPath: `/confirm-attendance/${CRN}/${sessionId}/non-compliance-reason`,
+      storedData: ['confirm-attendance', CRN, sessionId, 'was-absence-acceptable'],
+      excludedValues: [],
+      forkPath: `/confirm-attendance/${CRN}/${sessionId}/rar-categories`
+    },
+    {
+      currentPath: `/confirm-attendance/${CRN}/${sessionId}/add-notes`,
+      storedData: ['confirm-attendance', CRN, sessionId, 'add-notes'],
+      values: ['No'],
+      forkPath: `/confirm-attendance/${CRN}/${sessionId}/check`
+    }
   ]
 
   return nextForkPath(forks, req)

--- a/app/utils/wizard-helpers.js
+++ b/app/utils/wizard-helpers.js
@@ -39,15 +39,16 @@ function nextForkPath (forks, req) {
   if (fork) {
     const storedData = helpers.getDataValue(req.session.data, fork.storedData)
     const storedValues = Array.isArray(storedData) ? storedData : [storedData]
+    const forkPath = (typeof fork.forkPath === 'function' ? fork.forkPath(storedData) : fork.forkPath)
 
     if (fork.values) {
       const values = Array.isArray(fork.values) ? fork.values : [fork.values]
 
       if (values.some(v => storedValues.indexOf(v) >= 0)) {
         data['forked-from'] = currentPath
-        data['forked-to'] = fork.forkPath
+        data['forked-to'] = forkPath
 
-        return fork.forkPath
+        return forkPath
       }
     }
 
@@ -56,9 +57,9 @@ function nextForkPath (forks, req) {
 
       if (!excludedValues.some(v => storedValues.indexOf(v) >= 0)) {
         data['forked-from'] = currentPath
-        data['forked-to'] = fork.forkPath
+        data['forked-to'] = forkPath
 
-        return fork.forkPath
+        return forkPath
       }
     }
   }

--- a/app/views/case/timeline.html
+++ b/app/views/case/timeline.html
@@ -60,7 +60,7 @@ Case summary
           {% endset %}
         {% elseif entry.type === 'Office visit' and not entry.outcome %}
           {% set body %}
-            {{ appWarningBanner('Attendance not confirmed. <a href="../../confirm-attendance/start.html">Confirm attendance</a>') }}
+            {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/start">Confirm attendance</a>') }}
           {% endset %}
         {% endif %}
 

--- a/app/views/case/timeline.html
+++ b/app/views/case/timeline.html
@@ -60,7 +60,7 @@ Case summary
           {% endset %}
         {% elseif entry.type === 'Office visit' and not entry.outcome %}
           {% set body %}
-            {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/start">Confirm attendance</a>') }}
+            {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/' + entry.sessionId + '">Confirm attendance</a>') }}
           {% endset %}
         {% endif %}
 

--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -20,41 +20,38 @@ Case summary
 
     <form action="rar-categories" method="post" class="form">
 
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">
-              Was {{ case.serviceUserPersonalDetails.firstName }}’s absence acceptable?
-            </h1>
-          </legend>
-          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="contact-2" name="contact" type="radio" value="phone"
-                data-aria-controls="conditional-contact-2">
-              <label class="govuk-label govuk-radios__label" for="contact-2">
-                Yes
-              </label>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-contact-2">
-              <div class="govuk-form-group">
-                <label class="govuk-label" for="contact-by-phone">
-                  <strong>Why was this absence acceptable?</strong>
-                </label>
-                <input class="govuk-input govuk-!-width-two-thirds" id="contact-by-phone" name="contact-by-phone"
-                  type="tel">
-              </div>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="contact" name="contact" type="radio" value="email"
-                data-aria-controls="conditional-contact">
-              <label class="govuk-label govuk-radios__label" for="contact">
-                No
-              </label>
-            </div>
-          </div>
+      {% set whyAcceptableHtml %}
+        {{ govukInput({
+          label: {
+            text: "Why was this absence acceptable?"
+          },
+          classes: 'govuk-!-width-two-thirds'
+        } | decorateFormAttributes(['confirm-a-session', CRN, 'why-absence-acceptable'])) }}
+      {% endset %}
 
-        </fieldset>
-      </div>
+      {{ govukRadios({
+           fieldset: {
+             legend: {
+               text: "Was " + case.serviceUserPersonalDetails.firstName + "’s absence acceptable?",
+               classes: "govuk-label--l"
+             }
+           },
+           name: 'session-counts-towards-rar',
+           items: [
+             {
+               text: 'Yes',
+               value: 'Yes',
+               conditional: {
+                 html: whyAcceptableHtml
+               }
+             },
+             {
+               text: 'No',
+               value: 'No'
+             }
+           ]
+           } | decorateFormAttributes(['confirm-a-session', CRN, 'was-absence-acceptable']))
+      }}
 
       <button class="govuk-button send-message">
         Save and continue

--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -1,63 +1,37 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = "Was " + case.serviceUserPersonalDetails.firstName + "’s absence acceptable?" %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
+{% block form %}
+  {% set whyAcceptableHtml %}
+    {{ govukInput({
+      label: {
+        text: "Why was this absence acceptable?"
+      },
+      classes: 'govuk-!-width-two-thirds'
+    } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'why-absence-acceptable'])) }}
+  {% endset %}
 
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
-
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/rar-categories" method="post" class="form">
-
-      {% set whyAcceptableHtml %}
-        {{ govukInput({
-          label: {
-            text: "Why was this absence acceptable?"
-          },
-          classes: 'govuk-!-width-two-thirds'
-        } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'why-absence-acceptable'])) }}
-      {% endset %}
-
-      {{ govukRadios({
-           fieldset: {
-             legend: {
-               text: "Was " + case.serviceUserPersonalDetails.firstName + "’s absence acceptable?",
-               classes: "govuk-label--l"
-             }
-           },
-           name: 'session-counts-towards-rar',
-           items: [
-             {
-               text: 'Yes',
-               value: 'Yes',
-               conditional: {
-                 html: whyAcceptableHtml
-               }
-             },
-             {
-               text: 'No',
-               value: 'No'
-             }
-           ]
-           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
-      }}
-
-      <button class="govuk-button send-message">
-        Save and continue
-      </button>
-    </form>
-  </div>
-</div>
-
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: "Was " + case.serviceUserPersonalDetails.firstName + "’s absence acceptable?",
+           classes: "govuk-label--l"
+         }
+       },
+       name: 'session-counts-towards-rar',
+       items: [
+         {
+           text: 'Yes',
+           value: 'Yes',
+           conditional: {
+             html: whyAcceptableHtml
+           }
+         },
+         {
+           text: 'No',
+           value: 'No'
+         }
+       ]
+       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
+  }}
 {% endblock %}

--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -18,7 +18,7 @@ Case summary
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <form action="rar-categories" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/rar-categories" method="post" class="form">
 
       {% set whyAcceptableHtml %}
         {{ govukInput({
@@ -26,7 +26,7 @@ Case summary
             text: "Why was this absence acceptable?"
           },
           classes: 'govuk-!-width-two-thirds'
-        } | decorateFormAttributes(['confirm-a-session', CRN, 'why-absence-acceptable'])) }}
+        } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'why-absence-acceptable'])) }}
       {% endset %}
 
       {{ govukRadios({
@@ -50,7 +50,7 @@ Case summary
                value: 'No'
              }
            ]
-           } | decorateFormAttributes(['confirm-a-session', CRN, 'was-absence-acceptable']))
+           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
       }}
 
       <button class="govuk-button send-message">

--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -14,8 +14,9 @@
   {{ govukRadios({
        fieldset: {
          legend: {
-           text: "Was " + case.serviceUserPersonalDetails.firstName + "’s absence acceptable?",
-           classes: "govuk-label--l"
+           text: title,
+           classes: "govuk-label--xl",
+           isPageHeading: true
          }
        },
        name: 'session-counts-towards-rar',

--- a/app/views/confirm-attendance/add-notes.html
+++ b/app/views/confirm-attendance/add-notes.html
@@ -1,55 +1,28 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = "Would you like to add notes about this session?" %}
+{% set buttonText = 'Save and continue' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
-
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
-
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/notes" method="post" class="form">
-
-      {{ govukRadios({
-           fieldset: {
-             legend: {
-               text: "Would you like to add notes about this session?",
-               classes: "govuk-label--l"
-             }
-           },
-           hint: {
-             html: 'Notes can also be added later'
-           },
-           items: [
-             {
-               text: 'Yes',
-               value: 'Yes'
-             },
-             {
-               text: 'No',
-               value: 'No'
-             }
-           ]
-           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'add-notes']))
-      }}
-
-      <button class="govuk-button" data-module="govuk-button">
-        Save and continue
-      </button>
-
-    </form>
-
-  </div>
-</div>
-
+{% block form %}
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: "Would you like to add notes about this session?",
+           classes: "govuk-label--l"
+         }
+       },
+       hint: {
+         html: 'Notes can also be added later'
+       },
+       items: [
+         {
+           text: 'Yes',
+           value: 'Yes'
+         },
+         {
+           text: 'No',
+           value: 'No'
+         }
+       ]
+       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'add-notes']))
+  }}
 {% endblock %}

--- a/app/views/confirm-attendance/add-notes.html
+++ b/app/views/confirm-attendance/add-notes.html
@@ -6,8 +6,9 @@
   {{ govukRadios({
        fieldset: {
          legend: {
-           text: "Would you like to add notes about this session?",
-           classes: "govuk-label--l"
+           text: title,
+           classes: "govuk-label--xl",
+           isPageHeading: true
          }
        },
        hint: {

--- a/app/views/confirm-attendance/add-notes.html
+++ b/app/views/confirm-attendance/add-notes.html
@@ -18,7 +18,7 @@ Case summary
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <form action="notes" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/notes" method="post" class="form">
 
       {{ govukRadios({
            fieldset: {
@@ -40,7 +40,7 @@ Case summary
                value: 'No'
              }
            ]
-           } | decorateFormAttributes(['confirm-a-session', CRN, 'add-notes']))
+           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'add-notes']))
       }}
 
       <button class="govuk-button" data-module="govuk-button">

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -19,16 +19,16 @@ Case summary
 
     <h1 class="govuk-heading-l">Check your answers</h1>
 
-    <form action="confirmation" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/confirmation" method="post" class="form">
 
-      {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['confirm-a-session'][CRN]['did-service-user-comply'] == 'Absent' else data['confirm-a-session'][CRN]['did-service-user-comply']  %}
+      {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['confirm-attendance'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['confirm-attendance'][CRN][sessionId]['did-service-user-comply']  %}
 
       {{ govukSummaryList({
         classes: 'govuk-!-margin-bottom-9',
         rows: [
           {
             key: { text: "RAR activity" },
-            value: { text: data['confirm-a-session'][CRN]['RARCategory'] if data['confirm-a-session'][CRN]['countsTowardsRAR'] == 'Yes' else 'None'  },
+            value: { text: data['confirm-attendance'][CRN][sessionId]['RARCategory'] if data['confirm-attendance'][CRN][sessionId]['countsTowardsRAR'] == 'Yes' else 'None'  },
             actions: {
               items: [
                 {
@@ -54,7 +54,7 @@ Case summary
           },
           {
             key: { text: "Session notes" },
-            value: { text: data['confirm-a-session'][CRN]['notes'] if data['confirm-a-session'][CRN]['add-notes'] == 'Yes' else 'None' },
+            value: { text: data['confirm-attendance'][CRN][sessionId]['notes'] if data['confirm-attendance'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
             actions: {
               items: [
                 {

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -3,6 +3,8 @@
 {% set title = 'Check your answers' %}
 
 {% block form %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+
   {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['confirm-attendance'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['confirm-attendance'][CRN][sessionId]['did-service-user-comply']  %}
 
   {{ govukSummaryList({

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -1,87 +1,59 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set buttonText = 'Confirm attendance' %}
+{% set title = 'Check your answers' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
+{% block form %}
+  {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['confirm-attendance'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['confirm-attendance'][CRN][sessionId]['did-service-user-comply']  %}
 
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
-
-{% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
-{% endblock %}
-
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <h1 class="govuk-heading-l">Check your answers</h1>
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/confirmation" method="post" class="form">
-
-      {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['confirm-attendance'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['confirm-attendance'][CRN][sessionId]['did-service-user-comply']  %}
-
-      {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-9',
-        rows: [
-          {
-            key: { text: "RAR activity" },
-            value: { text: data['confirm-attendance'][CRN][sessionId]['RARCategory'] if data['confirm-attendance'][CRN][sessionId]['countsTowardsRAR'] == 'Yes' else 'None'  },
-            actions: {
-              items: [
-                {
-                  href: "rar-categories",
-                  text: "Change",
-                  visuallyHiddenText: "RAR activity"
-                }
-              ]
+  {{ govukSummaryList({
+    classes: 'govuk-!-margin-bottom-9',
+    rows: [
+      {
+        key: { text: "RAR activity" },
+        value: { text: data['confirm-attendance'][CRN][sessionId]['RARCategory'] if data['confirm-attendance'][CRN][sessionId]['countsTowardsRAR'] == 'Yes' else 'None'  },
+        actions: {
+          items: [
+            {
+              href: "rar-categories",
+              text: "Change",
+              visuallyHiddenText: "RAR activity"
             }
-          },
-          {
-            key: { text: case.serviceUserPersonalDetails.firstName + " complied?" },
-            value: { text: complianceText },
-            actions: {
-              items: [
-                {
-                  href: "compliance",
-                  text: "Change",
-                  visuallyHiddenText: "compliance"
-                }
-              ]
+          ]
+        }
+      },
+      {
+        key: { text: case.serviceUserPersonalDetails.firstName + " complied?" },
+        value: { text: complianceText },
+        actions: {
+          items: [
+            {
+              href: "compliance",
+              text: "Change",
+              visuallyHiddenText: "compliance"
             }
-          },
-          {
-            key: { text: "Session notes" },
-            value: { text: data['confirm-attendance'][CRN][sessionId]['notes'] if data['confirm-attendance'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
-            actions: {
-              items: [
-                {
-                  href: "add-notes",
-                  text: "Change",
-                  visuallyHiddenText: "session notes"
-                }
-              ]
+          ]
+        }
+      },
+      {
+        key: { text: "Session notes" },
+        value: { text: data['confirm-attendance'][CRN][sessionId]['notes'] if data['confirm-attendance'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
+        actions: {
+          items: [
+            {
+              href: "add-notes",
+              text: "Change",
+              visuallyHiddenText: "session notes"
             }
-          }
-        ]
-        }) }}
+          ]
+        }
+      }
+    ]
+    }) }}
 
-      <p class="govuk-body">You’re confirming attendance for:</p>
+  <p class="govuk-body">You’re confirming attendance for:</p>
 
-      <div class="govuk-inset-text">
-        <strong>{{ case.previousAppointment.type }}</strong><br>
-        {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
-      </div>
-
-      <button class="govuk-button" data-module="govuk-button">
-        Confirm attendance
-      </button>
-
-    </form>
-
+  <div class="govuk-inset-text">
+    <strong>{{ case.previousAppointment.type }}</strong><br>
+    {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
   </div>
-</div>
-
 {% endblock %}

--- a/app/views/confirm-attendance/compliance.html
+++ b/app/views/confirm-attendance/compliance.html
@@ -1,57 +1,29 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = 'Did ' + case.serviceUserPersonalDetails.firstName + ' comply?' %}
+{% set buttonText = 'Save and continue' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
-
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
-
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/non-compliance-reason" method="post" class="form">
-
-      {{ govukRadios({
-           fieldset: {
-             legend: {
-               text: 'Did ' + case.serviceUserPersonalDetails.firstName + ' comply?',
-               classes: "govuk-label--l"
-             }
-           },
-           items: [
-             {
-               text: 'Yes',
-               value: 'Yes'
-             },
-             {
-               text: 'No',
-               value: 'No'
-             },
-             {
-               text: case.serviceUserPersonalDetails.firstName + ' was absent',
-               value: 'Absent'
-             }
-           ]
-           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'did-service-user-comply']))
-      }}
-
-      <button class="govuk-button" data-module="govuk-button">
-        Save and continue
-      </button>
-
-    </form>
-
-
-  </div>
-
-</div>
-
+{% block form %}
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: 'Did ' + case.serviceUserPersonalDetails.firstName + ' comply?',
+           classes: "govuk-label--l"
+         }
+       },
+       items: [
+         {
+           text: 'Yes',
+           value: 'Yes'
+         },
+         {
+           text: 'No',
+           value: 'No'
+         },
+         {
+           text: case.serviceUserPersonalDetails.firstName + ' was absent',
+           value: 'Absent'
+         }
+       ]
+       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'did-service-user-comply']))
+  }}
 {% endblock %}

--- a/app/views/confirm-attendance/compliance.html
+++ b/app/views/confirm-attendance/compliance.html
@@ -6,8 +6,9 @@
   {{ govukRadios({
        fieldset: {
          legend: {
-           text: 'Did ' + case.serviceUserPersonalDetails.firstName + ' comply?',
-           classes: "govuk-label--l"
+           text: title,
+           classes: "govuk-label--xl",
+           isPageHeading: true
          }
        },
        items: [

--- a/app/views/confirm-attendance/compliance.html
+++ b/app/views/confirm-attendance/compliance.html
@@ -17,7 +17,7 @@ Case summary
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <form action="non-compliance-reason" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/non-compliance-reason" method="post" class="form">
 
       {{ govukRadios({
            fieldset: {
@@ -40,7 +40,7 @@ Case summary
                value: 'Absent'
              }
            ]
-           } | decorateFormAttributes(['confirm-a-session', CRN, 'did-service-user-comply']))
+           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'did-service-user-comply']))
       }}
 
       <button class="govuk-button" data-module="govuk-button">

--- a/app/views/confirm-attendance/confirmation.html
+++ b/app/views/confirm-attendance/confirmation.html
@@ -1,48 +1,23 @@
-{% extends "layout.html" %}
+{% extends "_wizard-page.html" %}
+{% set buttonText = 'Arrange a session' %}
+{% set title = "Attendance confirmed" %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
+{% block page %}
 
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
+  {% set panelHtml %}
+    <strong>{{ case.previousAppointment.type }}</strong><br>
+    {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
+  {% endset %}
 
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
+  {{ govukPanel({
+    titleText: title,
+    html: panelHtml
+  }) }}
 
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <div class="govuk-!-margin-bottom-7">
-      <div class="govuk-panel govuk-panel--confirmation">
-        <h1 class="govuk-panel__title">
-          Attendance confirmed
-        </h1>
-        <div class="govuk-panel__body">
-          <strong>{{ case.previousAppointment.type }}</strong><br>
-          {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
-        </div>
-      </div>
-    </div>
-
-    <h2 class="govuk-heading-m">Next steps</h2>
-
-
-    <a href="/arrange-a-session/{{ case.CRN }}/start" class="govuk-button">
-      Arrange a session
-    </a>
+  <h2 class="govuk-heading-m">Next steps</h2>
 
     <div style="margin-top: 20px;">
       <a class="govuk-body" href="/cases/{{ case.CRN }}/timeline">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
         sessions</a>
     </div>
-
-  </div>
-</div>
-
 {% endblock %}

--- a/app/views/confirm-attendance/non-compliance-reason.html
+++ b/app/views/confirm-attendance/non-compliance-reason.html
@@ -1,62 +1,38 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = "How did " + case.serviceUserPersonalDetails.firstName + " not comply?" %}
+{% set buttonText = 'Save and continue' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
+{% block form %}
+  {% set whyAcceptableHtml %}
+    {{ govukInput({
+      label: {
+        text: "Give details"
+      },
+      classes: 'govuk-!-width-two-thirds'
+    } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'non-compliance-reason'])) }}
+  {% endset %}
 
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
-
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/rar-categories" method="post" class="form">
-      {% set whyAcceptableHtml %}
-        {{ govukInput({
-          label: {
-            text: "Give details"
-          },
-          classes: 'govuk-!-width-two-thirds'
-        } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'non-compliance-reason'])) }}
-      {% endset %}
-
-      {{ govukRadios({
-           fieldset: {
-             legend: {
-               text: "How did " + case.serviceUserPersonalDetails.firstName + " not comply?",
-               classes: "govuk-label--l"
-             }
-           },
-           name: 'session-counts-towards-rar',
-           items: [
-             {
-               text: 'Behavioural issues',
-               value: 'Behavioural issues'
-             },
-             {
-               text: 'Other',
-               value: 'Other',
-               conditional: {
-                 html: whyAcceptableHtml
-               }
-             }
-           ]
-           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
-      }}
-
-      <button class="govuk-button send-message">
-        Save and continue
-      </button>
-    </form>
-  </div>
-</div>
-
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: "How did " + case.serviceUserPersonalDetails.firstName + " not comply?",
+           classes: "govuk-label--l"
+         }
+       },
+       name: 'session-counts-towards-rar',
+       items: [
+         {
+           text: 'Behavioural issues',
+           value: 'Behavioural issues'
+         },
+         {
+           text: 'Other',
+           value: 'Other',
+           conditional: {
+             html: whyAcceptableHtml
+           }
+         }
+       ]
+       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
+  }}
 {% endblock %}

--- a/app/views/confirm-attendance/non-compliance-reason.html
+++ b/app/views/confirm-attendance/non-compliance-reason.html
@@ -19,42 +19,38 @@ Case summary
   <div class="govuk-grid-column-two-thirds">
 
     <form action="rar-categories" method="post" class="form">
+      {% set whyAcceptableHtml %}
+        {{ govukInput({
+          label: {
+            text: "Give details"
+          },
+          classes: 'govuk-!-width-two-thirds'
+        } | decorateFormAttributes(['confirm-a-session', CRN, 'non-compliance-reason'])) }}
+      {% endset %}
 
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">
-              How did {{ case.serviceUserPersonalDetails.firstName }} not comply?
-            </h1>
-          </legend>
-          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="contact" name="contact" type="radio" value="email"
-                data-aria-controls="conditional-contact">
-              <label class="govuk-label govuk-radios__label" for="contact">
-                Behavioural issues
-              </label>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="contact-2" name="contact" type="radio" value="phone"
-                data-aria-controls="conditional-contact-2">
-              <label class="govuk-label govuk-radios__label" for="contact-2">
-                Other
-              </label>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-contact-2">
-              <div class="govuk-form-group">
-                <label class="govuk-label" for="contact-by-phone">
-                  <strong>Give details</strong>
-                </label>
-                <input class="govuk-input govuk-!-width-two-thirds" id="contact-by-phone" name="contact-by-phone"
-                  type="tel">
-              </div>
-            </div>
-          </div>
-
-        </fieldset>
-      </div>
+      {{ govukRadios({
+           fieldset: {
+             legend: {
+               text: "How did " + case.serviceUserPersonalDetails.firstName + " not comply?",
+               classes: "govuk-label--l"
+             }
+           },
+           name: 'session-counts-towards-rar',
+           items: [
+             {
+               text: 'Behavioural issues',
+               value: 'Behavioural issues'
+             },
+             {
+               text: 'Other',
+               value: 'Other',
+               conditional: {
+                 html: whyAcceptableHtml
+               }
+             }
+           ]
+           } | decorateFormAttributes(['confirm-a-session', CRN, 'was-absence-acceptable']))
+      }}
 
       <button class="govuk-button send-message">
         Save and continue

--- a/app/views/confirm-attendance/non-compliance-reason.html
+++ b/app/views/confirm-attendance/non-compliance-reason.html
@@ -16,7 +16,8 @@
        fieldset: {
          legend: {
            text: "How did " + case.serviceUserPersonalDetails.firstName + " not comply?",
-           classes: "govuk-label--l"
+           classes: "govuk-label--xl",
+           isPageHeading: true
          }
        },
        name: 'session-counts-towards-rar',

--- a/app/views/confirm-attendance/non-compliance-reason.html
+++ b/app/views/confirm-attendance/non-compliance-reason.html
@@ -18,14 +18,14 @@ Case summary
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <form action="rar-categories" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/rar-categories" method="post" class="form">
       {% set whyAcceptableHtml %}
         {{ govukInput({
           label: {
             text: "Give details"
           },
           classes: 'govuk-!-width-two-thirds'
-        } | decorateFormAttributes(['confirm-a-session', CRN, 'non-compliance-reason'])) }}
+        } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'non-compliance-reason'])) }}
       {% endset %}
 
       {{ govukRadios({
@@ -49,7 +49,7 @@ Case summary
                }
              }
            ]
-           } | decorateFormAttributes(['confirm-a-session', CRN, 'was-absence-acceptable']))
+           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
       }}
 
       <button class="govuk-button send-message">

--- a/app/views/confirm-attendance/notes.html
+++ b/app/views/confirm-attendance/notes.html
@@ -1,99 +1,72 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = "Add notes" %}
+{% set buttonText = 'Save and continue' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
-
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
-
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/check" method="post" class="form">
-
-      <div class="govuk-form-group">
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              You may want to use the CRISS format to write session notes
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <h2 class="govuk-heading-s">
-              Check-in
-              <br>
-              <span class="govuk-body">
-                What has happened in their life since the previous session? Clarify role boundaries and assess any
-                change in risk
-              </span>
-            </h2>
-            <h2 class="govuk-heading-s">
-              Review
-              <br>
-              <span class="govuk-body">
-                Review previous sessions and tasks and record progress against the sentence plan
-              </span>
-            </h2>
-            <h2 class="govuk-heading-s">
-              Implement
-              <br>
-              <span class="govuk-body">
-                Target criminogenic needs and risk status
-              </span>
-            </h2>
-            <h2 class="govuk-heading-s">
-              Summarise
-              <br>
-              <span class="govuk-body">
-                Summarise the purpose of the session
-              </span>
-            </h2>
-            <h2 class="govuk-heading-s">
-              Set tasks
-              <br>
-              <span class="govuk-body">
-                Set and agree tasks and confirm the next session
-              </span>
-            </h2>
-          </div>
-        </details>
-
-        {{ govukTextarea({
-          name: "notes",
-          id: "notes",
-          rows: 10
-        } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'notes'])) }}
-
+{% block form %}
+  <div class="govuk-form-group">
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          You may want to use the CRISS format to write session notes
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <h2 class="govuk-heading-s">
+          Check-in
+          <br>
+          <span class="govuk-body">
+            What has happened in their life since the previous session? Clarify role boundaries and assess any
+            change in risk
+          </span>
+        </h2>
+        <h2 class="govuk-heading-s">
+          Review
+          <br>
+          <span class="govuk-body">
+            Review previous sessions and tasks and record progress against the sentence plan
+          </span>
+        </h2>
+        <h2 class="govuk-heading-s">
+          Implement
+          <br>
+          <span class="govuk-body">
+            Target criminogenic needs and risk status
+          </span>
+        </h2>
+        <h2 class="govuk-heading-s">
+          Summarise
+          <br>
+          <span class="govuk-body">
+            Summarise the purpose of the session
+          </span>
+        </h2>
+        <h2 class="govuk-heading-s">
+          Set tasks
+          <br>
+          <span class="govuk-body">
+            Set and agree tasks and confirm the next session
+          </span>
+        </h2>
       </div>
+    </details>
 
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-!-font-weight-bold" for="case-note-description">
-          Upload files
-        </label>
-        <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file"
-          aria-describedby="file-upload-1-hint">
-      </div>
+    {{ govukTextarea({
+      name: "notes",
+      id: "notes",
+      rows: 10
+    } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'notes'])) }}
 
-      <div style="display:flex;">
-        <button class="govuk-button send-message">
-          Save and continue
-        </button>
-      </div>
-      <p class="govuk-hint">
-        This will be added to the nDelius contact log.
-      </p>
-
-    </form>
   </div>
-</div>
 
+  <div class="govuk-form-group">
+    <label class="govuk-label govuk-!-font-weight-bold" for="case-note-description">
+      Upload files
+    </label>
+    <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file"
+      aria-describedby="file-upload-1-hint">
+  </div>
+
+  <p class="govuk-hint">
+    This will be added to the nDelius contact log.
+  </p>
 {% endblock %}

--- a/app/views/confirm-attendance/notes.html
+++ b/app/views/confirm-attendance/notes.html
@@ -18,7 +18,7 @@ Case summary
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <form action="check" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/check" method="post" class="form">
 
       <div class="govuk-form-group">
         <details class="govuk-details" data-module="govuk-details">
@@ -71,7 +71,7 @@ Case summary
           name: "notes",
           id: "notes",
           rows: 10
-        } | decorateFormAttributes(['confirm-a-session', CRN, 'notes'])) }}
+        } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'notes'])) }}
 
       </div>
 

--- a/app/views/confirm-attendance/rar-categories.html
+++ b/app/views/confirm-attendance/rar-categories.html
@@ -38,8 +38,9 @@
   {{ govukRadios({
        fieldset: {
          legend: {
-           text: "Would you like this to count towards RAR?",
-           classes: "govuk-label--l"
+           text: title,
+           classes: "govuk-label--xl",
+           isPageHeading: true
          }
        },
        hint: {

--- a/app/views/confirm-attendance/rar-categories.html
+++ b/app/views/confirm-attendance/rar-categories.html
@@ -1,90 +1,62 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = "Would you like this to count towards RAR?" %}
+{% set buttonText = 'Save and continue' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
+{% block form %}
+  {% set rarCategories = [
+    'Employment, Training and Education',
+    'Wellbeing – both physical and mental',
+    'Finance, benefit and debt',
+    'Relationships',
+    'Restorative Justice Interventions',
+    'Substance Misuse',
+    'Alcohol Treatment Requirements or Mental Health Treatment Requirements',
+    'Thinking skills, attitudes and behaviour'
+  ] %}
 
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
+  {% set rarRadioItems = [] %}
+  {% for rarCategory in rarCategories %}
+    {% set rarRadioItems = (rarRadioItems.push({
+      text: rarCategory,
+      value: rarCategory,
+      checked: checked("session-rar-category", rarCategory)
+    }), rarRadioItems) %}
+  {% endfor %}
 
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/add-notes" method="post" class="form">
-
-      {% set rarCategories = [
-        'Employment, Training and Education',
-        'Wellbeing – both physical and mental',
-        'Finance, benefit and debt',
-        'Relationships',
-        'Restorative Justice Interventions',
-        'Substance Misuse',
-        'Alcohol Treatment Requirements or Mental Health Treatment Requirements',
-        'Thinking skills, attitudes and behaviour'
-      ] %}
-
-      {% set rarRadioItems = [] %}
-      {% for rarCategory in rarCategories %}
-        {% set rarRadioItems = (rarRadioItems.push({
-          text: rarCategory,
-          value: rarCategory,
-          checked: checked("session-rar-category", rarCategory)
-        }), rarRadioItems) %}
-      {% endfor %}
-
-      {% set rarCategoryHtml %}
-        {{ govukRadios({
-               fieldset: {
-                 legend: {
-                   text: "What will this session count towards?"
-                 }
-               },
-               items: rarRadioItems
-             } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'RARCategory']) )
-          }}
-      {% endset %}
-
-      {{ govukRadios({
+  {% set rarCategoryHtml %}
+    {{ govukRadios({
            fieldset: {
              legend: {
-               text: "Would you like this to count towards RAR?",
-               classes: "govuk-label--l"
+               text: "What will this session count towards?"
              }
            },
-           hint: {
-             html: 'This will account for one day of Rehabilitation Activity Requirement (RAR).'
-           },
-           items: [
-             {
-               text: 'Yes',
-               value: 'Yes',
-               conditional: {
-                 html: rarCategoryHtml
-               }
-             },
-             {
-               text: 'No',
-               value: 'No'
-             }
-           ]
-           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'countsTowardsRAR']) ) }}
+           items: rarRadioItems
+         } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'RARCategory']) )
+      }}
+  {% endset %}
 
-      <button class="govuk-button" data-module="govuk-button">
-        Save and continue
-      </button>
-
-    </form>
-
-
-  </div>
-
-</div>
-
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: "Would you like this to count towards RAR?",
+           classes: "govuk-label--l"
+         }
+       },
+       hint: {
+         html: 'This will account for one day of Rehabilitation Activity Requirement (RAR).'
+       },
+       items: [
+         {
+           text: 'Yes',
+           value: 'Yes',
+           conditional: {
+             html: rarCategoryHtml
+           }
+         },
+         {
+           text: 'No',
+           value: 'No'
+         }
+       ]
+       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'countsTowardsRAR']) ) }}
 {% endblock %}

--- a/app/views/confirm-attendance/rar-categories.html
+++ b/app/views/confirm-attendance/rar-categories.html
@@ -17,7 +17,7 @@ Case summary
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <form action="add-notes" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/add-notes" method="post" class="form">
 
       {% set rarCategories = [
         'Employment, Training and Education',
@@ -47,7 +47,7 @@ Case summary
                  }
                },
                items: rarRadioItems
-             } | decorateFormAttributes(['confirm-a-session', CRN, 'RARCategory']) )
+             } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'RARCategory']) )
           }}
       {% endset %}
 
@@ -74,7 +74,7 @@ Case summary
                value: 'No'
              }
            ]
-           } | decorateFormAttributes(['confirm-a-session', CRN, 'countsTowardsRAR']) ) }}
+           } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'countsTowardsRAR']) ) }}
 
       <button class="govuk-button" data-module="govuk-button">
         Save and continue

--- a/app/views/confirm-attendance/start.html
+++ b/app/views/confirm-attendance/start.html
@@ -1,42 +1,13 @@
-{% extends "layout.html" %}
+{% extends "_wizard-form.html" %}
+{% set title = 'Confirm attendance' %}
 
-{% block pageTitle %}
-Case summary
-{% endblock %}
+{% block form %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-{% block keyDetails %}
-  {% include "includes/service-user-banner.html" %}
-{% endblock %}
+  <p class="govuk-body">You’re confirming attendance for:</p>
 
-{% block beforeContent %}
-<a href="/cases/{{ case.CRN }}/timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous
-  sessions</a>
-{% endblock %}
-
-{% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <h1 class="govuk-heading-l">Confirm attendance</h1>
-
-    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/compliance" method="post" class="form">
-
-      <p class="govuk-body">You’re confirming attendance for:</p>
-
-      <div class="govuk-inset-text">
-        <strong>{{ case.previousAppointment.type }}</strong><br>
-        {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
-      </div>
-
-      <button class="govuk-button" data-module="govuk-button">
-        Continue
-      </button>
-
-    </form>
-
-
+  <div class="govuk-inset-text">
+    <strong>{{ case.previousAppointment.type }}</strong><br>
+    {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
   </div>
-
-</div>
-
 {% endblock %}

--- a/app/views/confirm-attendance/start.html
+++ b/app/views/confirm-attendance/start.html
@@ -19,7 +19,7 @@ Case summary
 
     <h1 class="govuk-heading-l">Confirm attendance</h1>
 
-    <form action="compliance" method="post" class="form">
+    <form action="/confirm-attendance/{{ case.CRN }}/{{ sessionId }}/compliance" method="post" class="form">
 
       <p class="govuk-body">You’re confirming attendance for:</p>
 


### PR DESCRIPTION
* Use Nunjucks macros where possible
* Add CRN and a session ID into the URL to enable confirming attendance for multiple appointments
* Update visual design to be in line with the 'arrange a session' flow
* Update the routing to use the new wizard routing, which allows for consistent back links
* De-duplicate the template markup by using the wizard form template