### PR TITLE
Clean up of application.scss

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -20,6 +20,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/filter";
 @import "components/timeline";
 @import "components/key-details-bar";
+@import "components/time-autocomplete";
 
 @import 'accessible-autocomplete.min';
 @import 'max-widths';
@@ -169,35 +170,6 @@ $govuk-assets-path: '/govuk/assets/';
 
 .note-panel ul {
   margin-top: 0;
-}
-
-/*the container must be positioned relative:*/
-.autocomplete {
-  position: relative;
-  display: inline-block;
-}
-
-.autocomplete-items {
-  position: absolute;
-  border: 2px solid #0b0c0c;
-  border-top: none;
-  z-index: 99;
-  /*position the autocomplete items to be the same width as the container:*/
-  top: 100%;
-  left: 0;
-  right: 0;
-}
-
-.autocomplete-items div {
-  padding: 8px;
-  cursor: pointer;
-  background-color: #fff;
-  border-bottom: 1px solid #d4d4d4;
-}
-
-/*when hovering an item:*/
-.autocomplete-items div:hover {
-  background-color: #f3f2f1;
 }
 
 .govuk-hint-s {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -31,19 +31,6 @@ $govuk-assets-path: '/govuk/assets/';
     background-image: url(/public/images/icon-document.svg) !important;
 }
 
-// Caselist timestamp
-.case-list-timestamp {
-    float: none;
-    margin-right: 0;
-}
-
-@media (min-width: 1024px) {
-    .case-list-timestamp {
-        float: right;
-        margin-right: 0;
-    }
-}
-
 .app-cases-table td ol {
   margin-top: 0;
   margin-bottom: 0;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -24,6 +24,7 @@ $govuk-assets-path: '/govuk/assets/';
 
 @import 'accessible-autocomplete.min';
 @import 'max-widths';
+@import 'govuk-page-masthead';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
@@ -60,34 +61,9 @@ $govuk-assets-path: '/govuk/assets/';
   color: $govuk-secondary-text-colour;
 }
 
-// Prototype index page styles
-
-.app-masthead {
-  padding-top: 20px;
-  padding-bottom: 20px;
-  color: govuk-colour("white");
-  background-color: $govuk-brand-colour;
-  margin-top: -20px;
-}
-
-@media (min-width: 40.0625em) {
-  .app-masthead {
-    padding-top: 40px;
-  }
-}
-
-.app-masthead__title,
-.app-masthead__subtitle,
-.app-masthead p {
-    color: govuk-colour("white") !important;
-}
-
-.app-masthead__subtitle {
-  font-weight: normal !important;
-}
-
-.panel .grid-row {
-    margin-top: 32px;
+.app-organisation-nav-title {
+  float: right;
+  padding-top: 19px;
 }
 
 .app-case-updates {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -19,6 +19,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/cookie-banner";
 @import "components/filter";
 @import "components/timeline";
+@import "components/key-details-bar";
 
 @import 'accessible-autocomplete.min';
 @import 'max-widths';
@@ -74,79 +75,6 @@ $govuk-assets-path: '/govuk/assets/';
 // Secondary text colour
 .secondary-text-col {
   color: $govuk-secondary-text-colour;
-}
-
-// Key details bar
-.key-details-bar {
-    background-color: govuk-colour("blue");
-}
-
-.key-details-bar .key-details-bar__key-details {
-    padding: 20px 0;
-    position: relative;
-}
-
-.key-details-bar .key-details-bar__key-details .key-details-bar__name {
-    font-family: "GDS Transport", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 24px;
-    font-size: 1.5rem;
-    line-height: 1.04167;
-    font-weight: 700;
-    line-height: 1.11111;
-    margin-right: 10px;
-    -webkit-margin-start: 0;
-    margin-inline-start: 0;
-}
-
-.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
-    padding-top: 10px;
-    margin-top: 6px;
-}
-
-.key-details-bar .key-details-bar__key-details .key-details-bar__status {
-    font-family: "GDS Transport", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 14px;
-    font-size: 0.875rem;
-    line-height: 1.14286;
-    font-weight: 700;
-    line-height: 1.25;
-    padding: 5px 8px;
-    color: govuk-colour("blue");
-    background-color: #ffffff;
-    letter-spacing: 1px;
-    text-decoration: none;
-    text-transform: uppercase;
-    float: right;
-    margin: 5px 0 0;
-}
-
-.key-details-bar .key-details-bar__key-details * {
-    color: #ffffff;
-}
-
-.key-details-bar_divider {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
-    margin: 0 15px 0 0;
-    padding: 0 15px 0 0;
-}
-
-@media (min-width: 40.0625em) {
-    .key-details-bar .key-details-bar__key-details .key-details-bar__name {
-        font-size: 1.675rem;
-        line-height: 1.11111;
-    }
-
-    .key-details-bar .key-details-bar__key-details .key-details-bar__status {
-        font-size: 16px;
-        font-size: 1rem;
-        line-height: 1.25;
-    }
 }
 
 // Sub navigation

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -24,24 +24,9 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
-
-// Search toggle image
-.moj-search-toggle__button:after {
-    background-image: url(/public/images/icon-search-blue.svg) !important;
-}
-
 // Document icon image
 .moj-timeline__document-link {
     background-image: url(/public/images/icon-document.svg) !important;
-}
-
-// Button menu toggle icon
-.moj-button-menu__toggle-button--secondary:after {
-    background-image: url(/public/images/icon-arrow-black-down.svg) !important;
-}
-
-.moj-button-menu button {
-    color: #000000 !important;
 }
 
 // Container max width
@@ -138,8 +123,6 @@ $govuk-assets-path: '/govuk/assets/';
     }
 }
 
-
-// Case list overrides
 .app-cases-table td ol {
   margin-top: 0;
   margin-bottom: 0;
@@ -163,32 +146,15 @@ $govuk-assets-path: '/govuk/assets/';
     }
 }
 
-.moj-tag--small--nowrap {
-    white-space: nowrap;
-    font-size: 0.875rem;
-    padding-bottom: 5px;
-}
-
 .card .govuk-inset-text {
     border-left: 5px solid #b1b4b6;
     padding: 0 15px;
 }
 
-
-// Highlight
-.highlight {
-    border-bottom: 3px solid #ffbf47;
-    margin-right: 1px;
-    background-color: #fff2d3;
-    padding: 2px 0px 0px;
-}
-
-
 // Secondary text colour
 .secondary-text-col {
-    color: $govuk-secondary-text-colour;
+  color: $govuk-secondary-text-colour;
 }
-
 
 // Key details bar
 .key-details-bar {
@@ -196,8 +162,6 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .key-details-bar .key-details-bar__key-details {
-    // max-width: 1200px;
-    // margin: 0 auto;
     padding: 20px 0;
     position: relative;
 }
@@ -218,8 +182,6 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
-    // border-top: 1px solid rgba(255, 255, 255, 0.3);
-    // content: ' ';
     padding-top: 10px;
     margin-top: 6px;
 }
@@ -255,13 +217,7 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 @media (min-width: 40.0625em) {
-
-    // .key-details-bar .key-details-bar__key-details {
-    //     margin: 0 auto;
-    // }
     .key-details-bar .key-details-bar__key-details .key-details-bar__name {
-        // font-size: 36px;
-        // font-size: 2.25rem;
         font-size: 1.675rem;
         line-height: 1.11111;
     }
@@ -271,110 +227,6 @@ $govuk-assets-path: '/govuk/assets/';
         font-size: 1rem;
         line-height: 1.25;
     }
-}
-
-// DASHBOARD
-
-.app-pagination__list {
-    padding-left: 0;
-    margin: 0;
-}
-
-.app-pagination--inline .app-pagination__list-item {
-    display: inline-block;
-}
-
-.app-pagination__list-item {
-    display: block;
-}
-
-.app-pagination--inline .app-pagination__link {
-    display: block;
-}
-
-.app-pagination__link:active,
-.app-pagination__link:hover,
-.app-pagination__link:link,
-.app-pagination__link:visited {
-    color: #1d70b8;
-}
-
-.app-pagination__link {
-    display: block;
-    padding: 15px;
-    text-decoration: none;
-}
-
-
-.app-pagination__link-title {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
-    display: block;
-    font-weight: 700;
-}
-
-.app-pagination__link-icon {
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 18px;
-    font-size: 1.125rem;
-    line-height: 1.11111;
-    float: left;
-    height: 1em;
-    position: relative;
-    top: 1px;
-    width: .63em;
-}
-
-@media (min-width: 40.0625em) {
-
-    .app-pagination__link-title {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.31579;
-    }
-}
-
-@media (min-width: 40.0625em) {
-    .app-pagination__link-icon {
-        font-size: 24px;
-        font-size: 1.5rem;
-        line-height: 1.25;
-    }
-}
-
-.app-pagination__link:hover {
-    background-color: #f3f2f1;
-}
-
-.app-pagination--inline .app-pagination__list-item--next .app-pagination__link-icon {
-    float: right;
-}
-
-.app-pagination {
-    display: block;
-    list-style: none;
-    margin-left: -15px;
-    margin-right: -15px;
-}
-
-
-.app-pagination--inline .app-pagination__list-item--next .app-pagination__link-text {
-    margin-left: 0;
-    margin-right: 10px;
-}
-
-.app-pagination__list-item--next .app-pagination__link-text,
-.app-pagination__list-item--prev .app-pagination__link-text {
-    margin-left: 10px;
-}
-
-.app-pagination--inline .app-pagination__link-text {
-    font-weight: 400;
 }
 
 // Sub navigation
@@ -398,54 +250,6 @@ $govuk-assets-path: '/govuk/assets/';
         grid-template-columns: auto auto;
     }
 }
-
-
-// Overall attendance counts
-
-.app-dashboard-count {
-    padding-right: 10px !important;
-    text-align: right;
-    min-width: 30px !important;
-    display: inline-block;
-    margin-bottom: 0;
-}
-
-
-// Delius contact
-.delius-contact {
-    max-width: none;
-}
-
-.delius-contact .govuk-summary-list__key {
-    text-align: right !important;
-}
-
-.delius-contact .govuk-select {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 0.9em;
-    border: 1px solid #ccc;
-    height: 2rem;
-    width: 100%;
-    background-color: white;
-}
-
-.delius-contact .mandatory {
-    color: $govuk-error-colour;
-}
-
-.delius-contact .govuk-summary-list__value {
-    padding: 5px 0 5px 0;
-}
-
-.delius-contact button {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 0.9em;
-    border: 1px solid #ccc;
-    box-shadow: none;
-    padding: 10px 12px 9px;
-    border-radius: 4px;
-}
-
 
 // Prototype index page styles
 
@@ -477,54 +281,8 @@ $govuk-assets-path: '/govuk/assets/';
     margin-bottom: 15px !important;
 }
 
-@media (min-width: 641px) {
-    .most-recent {
-        padding-bottom: 50px;
-        padding-left: 25px;
-        padding-right: 25px;
-        padding-top: 50px;
-    }
-}
-
-.most-recent {
-    border: 1px solid $govuk-border-colour;
-    margin-bottom: 60px;
-    margin-top: 15px;
-    overflow: hidden;
-    position: relative;
-}
-
-.most-recent .recent-tag {
-    position: absolute;
-    top: -1px;
-    left: 0;
-}
-
-.prototype-index summary {
-    color: $govuk-link-colour;
-    font-family: "GDS Transport", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 19px;
-}
-
 .panel .grid-row {
     margin-top: 32px;
-}
-
-
-// Show more show less links
-.morecontent span {
-    display: none;
-}
-
-a.morelink {
-    color: #1d70b8;
-}
-
-a.morelink:visited {
-    color: #1d70b8;
 }
 
 .app-case-updates {
@@ -554,52 +312,6 @@ a.morelink:visited {
         margin-top: 15px;
     }
 }
-
-tr.case-history {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    justify-content: flex-start;
-}
-.expanded-row-content {
-    display: grid;
-    grid-column: 1/-1;
-    justify-content: flex-start;
-}
-.hide-row {
-    display: none;
-}
-tr.system td{
-    background-color: #ccc;
-  }
-
-.graph {
-    background: #d4ecea;
-}
-
-.graph div .amount {
-    font-family: "GDS Transport", Arial, sans-serif;
-    display: block;
-    height: 100%;
-    background: #28a197;
-    line-height: 1.8em;
-    color: #fff;
-    text-align: right;
-    font-size: 1.3em;
-    font-weight: 700;
-    padding-right: 0.75rem;
-}
-    .graph div .amount--none {
-        font-family: "GDS Transport", Arial, sans-serif;
-        display: block;
-        height: 100%;
-        background: #d4ecea;
-        line-height: 1.8em;
-        color: #0b0c0c;
-        text-align: left;
-        font-size: 1.3em;
-        font-weight: 700;
-        padding-left: 0.75rem;
-    }
 
 .govuk-panel--appointment {
         color: #ffffff;
@@ -639,27 +351,27 @@ tr.system td{
 
 @media (min-width: 40.0625em) {
 .govuk-panel__body {
-    font-size: 24px;
-    line-height: 1.4;
+  font-size: 24px;
+  line-height: 1.4;
     }
 }
 
 .govuk-panel__small {
-    font-size: 16px;
-    line-height: 1.3;
+  font-size: 16px;
+  line-height: 1.3;
 }
 
 @media (min-width: 40.0625em) {
-.govuk-panel__small {
+  .govuk-panel__small {
     font-size: 19px;
     line-height: 1.4;
-    }
+  }
 }
 
 .note-panel {
-    background-color: #f3f2f1;
-    padding: 1.5rem;
-    margin-bottom: 1rem;
+  background-color: #f3f2f1;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .note-panel ul {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -21,6 +21,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/timeline";
 @import "components/key-details-bar";
 @import "components/time-autocomplete";
+@import "components/cases-table";
 
 @import 'accessible-autocomplete.min';
 @import 'max-widths';
@@ -31,29 +32,6 @@ $govuk-assets-path: '/govuk/assets/';
 // Document icon image
 .moj-timeline__document-link {
   background-image: url(/public/images/icon-document.svg) !important;
-}
-
-.app-cases-table td ol {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 1.4em;
-}
-
-.app-cases-table td ul {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 0;
-  list-style-type: none;
-}
-
-@media screen and (min-width: 40.0625em) {
-  .app-cases-table .custom-delius-record-width {
-    min-width: 180px;
-  }
-
-  .app-cases-table .custom-defendant-width {
-    min-width: 160px;
-  }
 }
 
 // Secondary text colour

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -57,14 +57,14 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .govuk-panel--appointment-timeline {
-  color: #ffffff;
-  background: #1d70b8;
+  color: govuk-colour("white");
+  background: govuk-colour("blue");
   margin-bottom: 2rem;
   padding: 20px;
 }
 
 .note-panel {
-  background-color: #f3f2f1;
+  background-color: govuk-colour("light-grey");
   padding: 1.5rem;
   margin-bottom: 1rem;
 }
@@ -74,5 +74,5 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .govuk-hint-s {
-  color: #505a5f;
+  color: govuk-colour("dark-grey");
 }

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -97,17 +97,6 @@ $govuk-assets-path: '/govuk/assets/';
     margin-bottom: 25px;
 }
 
-.app-last-updated-stamp {
-    border-right: 1px solid #626a6e;
-    margin: 0 10px 0 0;
-    padding: 0 10px 0 0;
-}
-
-.app-last-updated-stamp,
-.app-next-update-stamp {
-    display: inline-block;
-}
-
 .app-organisation-nav-title {
     float: right;
     padding-top: 19px;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -82,11 +82,7 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .app-masthead__subtitle {
-    font-weight: normal !important;
-}
-
-.app-related-items .useful-links>li {
-    margin-bottom: 15px !important;
+  font-weight: normal !important;
 }
 
 .panel .grid-row {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -21,93 +21,13 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/timeline";
 
 @import 'accessible-autocomplete.min';
+@import 'max-widths';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
 // Document icon image
 .moj-timeline__document-link {
     background-image: url(/public/images/icon-document.svg) !important;
-}
-
-// Container max width
-.govuk-width-container,
-.moj-primary-navigation__container,
-.moj-header__container,
-.key-details-bar .key-details-bar__key-details {
-    max-width: 1220px;
-    margin: 0 15px;
-}
-
-@media (min-width: 40.0625em) {
-
-    .govuk-width-container,
-    .moj-primary-navigation__container,
-    .moj-header__container,
-    .key-details-bar .key-details-bar__key-details {
-        margin: 0 30px;
-    }
-}
-
-@media (min-width: 1020px) {
-
-    .govuk-width-container,
-    .moj-primary-navigation__container,
-    .moj-header__container,
-    .key-details-bar .key-details-bar__key-details {
-        margin: 0 30px;
-    }
-}
-
-@media (min-width: 1280px) {
-
-    .govuk-width-container,
-    .moj-primary-navigation__container,
-    .moj-header__container,
-    .key-details-bar .key-details-bar__key-details {
-        margin: 0 auto;
-    }
-}
-
-
-// Element max width
-
-.govuk-heading-s,
-.govuk-heading-m,
-.govuk-heading-l,
-.govuk-heading-xl,
-.govuk-body,
-.govuk-body-l,
-.govuk-body-s,
-.govuk-caption-m,
-.govuk-caption-l,
-.govuk-caption-xl,
-.govuk-link,
-.govuk-list,
-.govuk-label,
-.govuk-hint,
-.govuk-fieldset__legend,
-.govuk-fieldset__heading,
-.govuk-accordion__section-heading,
-.govuk-textarea,
-.govuk-details__summary,
-.govuk-details__text,
-.govuk-error-message,
-.govuk-error-summary__title,
-.govuk-inset-text,
-.govuk-panel__title,
-.govuk-panel__body,
-.govuk-warning-text__text,
-.govuk-phase-banner__content,
-.govuk-select,
-.govuk-table__caption,
-.govuk-summary-list,
-.govuk-accordion,
-.govuk-table {
-    max-width: 727px;
-}
-
-.govuk-table-xl {
-    max-width: none;
 }
 
 // Caselist timestamp

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -59,16 +59,6 @@ $govuk-assets-path: '/govuk/assets/';
   color: $govuk-secondary-text-colour;
 }
 
-// Sub navigation
-
-.moj-sub-navigation__item {
-    margin-right: 25px;
-}
-
-.moj-sub-navigation__item:last-child {
-    margin-right: 0;
-}
-
 // Radio time structure
 .wrapper {
     display: grid;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -56,59 +56,11 @@ $govuk-assets-path: '/govuk/assets/';
   }
 }
 
-.govuk-panel--appointment {
-  color: #ffffff;
-  background: #28a197;
-  margin-bottom: 2rem;
-}
-
-.govuk-panel--appointment-none {
-  color: #0b0c0c;
-  background: #f3f2f1;
-  margin-bottom: 2rem;
-}
-
 .govuk-panel--appointment-timeline {
   color: #ffffff;
   background: #1d70b8;
   margin-bottom: 2rem;
   padding: 20px;
-}
-
-.govuk-panel__title {
-  font-size: 27px;
-  line-height: 1;
-}
-
-@media (min-width: 40.0625em) {
-  .govuk-panel__title {
-    font-size: 36px;
-    line-height: 1;
-  }
-}
-
-.govuk-panel__body {
-  font-size: 19px;
-  line-height: 1.3;
-}
-
-@media (min-width: 40.0625em) {
-  .govuk-panel__body {
-    font-size: 24px;
-    line-height: 1.4;
-  }
-}
-
-.govuk-panel__small {
-  font-size: 16px;
-  line-height: 1.3;
-}
-
-@media (min-width: 40.0625em) {
-  .govuk-panel__small {
-    font-size: 19px;
-    line-height: 1.4;
-  }
 }
 
 .note-panel {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -62,23 +62,23 @@ $govuk-assets-path: '/govuk/assets/';
 // Prototype index page styles
 
 .app-masthead {
-    padding-top: 20px;
-    padding-bottom: 20px;
-    color: #ffffff;
-    background-color: $govuk-brand-colour;
-    margin-top: -20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: govuk-colour("white");
+  background-color: $govuk-brand-colour;
+  margin-top: -20px;
 }
 
 @media (min-width: 40.0625em) {
-    .app-masthead {
-        padding-top: 40px;
-    }
+  .app-masthead {
+    padding-top: 40px;
+  }
 }
 
 .app-masthead__title,
 .app-masthead__subtitle,
 .app-masthead p {
-    color: #ffffff !important;
+    color: govuk-colour("white") !important;
 }
 
 .app-masthead__subtitle {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -140,17 +140,17 @@ $govuk-assets-path: '/govuk/assets/';
 
 
 // Case list overrides
-td ol {
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-left: 1.4em;
+.app-cases-table td ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 1.4em;
 }
 
-td ul {
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-left: 0;
-    list-style-type: none;
+.app-cases-table td ul {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style-type: none;
 }
 
 @media screen and (min-width: 40.0625em) {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -45,18 +45,13 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 @media screen and (min-width: 40.0625em) {
-    .custom-delius-record-width {
-        min-width: 180px;
-    }
+  .app-cases-table .custom-delius-record-width {
+    min-width: 180px;
+  }
 
-    .custom-defendant-width {
-        min-width: 160px;
-    }
-}
-
-.card .govuk-inset-text {
-    border-left: 5px solid #b1b4b6;
-    padding: 0 15px;
+  .app-cases-table .custom-defendant-width {
+    min-width: 160px;
+  }
 }
 
 // Secondary text colour

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -299,16 +299,6 @@ td ul {
     color: #1d70b8;
 }
 
-.govuk-link:visited,
-a:visited {
-    color: #4c2c92;
-}
-
-.govuk-link:link,
-a:link {
-    color: #1d70b8;
-}
-
 .app-pagination__link {
     display: block;
     padding: 15px;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -29,7 +29,7 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Document icon image
 .moj-timeline__document-link {
-    background-image: url(/public/images/icon-document.svg) !important;
+  background-image: url(/public/images/icon-document.svg) !important;
 }
 
 .app-cases-table td ol {
@@ -91,63 +91,58 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .app-case-updates {
-    margin-bottom: 25px;
-}
-
-.app-organisation-nav-title {
-    float: right;
-    padding-top: 19px;
+  margin-bottom: 25px;
 }
 
 @media (min-width: 1100px) {
-    .app-case-updates {
-        float: right;
-        margin-bottom: 0;
-        margin-top: 15px;
-    }
+  .app-case-updates {
+    float: right;
+    margin-bottom: 0;
+    margin-top: 15px;
+  }
 }
 
 .govuk-panel--appointment {
-        color: #ffffff;
-        background: #28a197;
-        margin-bottom: 2rem;
-    }
+  color: #ffffff;
+  background: #28a197;
+  margin-bottom: 2rem;
+}
 
 .govuk-panel--appointment-none {
-        color: #0b0c0c;
-        background: #f3f2f1;
-        margin-bottom: 2rem;
-    }
+  color: #0b0c0c;
+  background: #f3f2f1;
+  margin-bottom: 2rem;
+}
 
 .govuk-panel--appointment-timeline {
-        color: #ffffff;
-        background: #1d70b8;
-        margin-bottom: 2rem;
-        padding: 20px;
-    }
+  color: #ffffff;
+  background: #1d70b8;
+  margin-bottom: 2rem;
+  padding: 20px;
+}
 
 .govuk-panel__title {
-    font-size: 27px;
+  font-size: 27px;
+  line-height: 1;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-panel__title {
+    font-size: 36px;
     line-height: 1;
+  }
+}
+
+.govuk-panel__body {
+  font-size: 19px;
+  line-height: 1.3;
 }
 
 @media (min-width: 40.0625em) {
-    .govuk-panel__title {
-        font-size: 36px;
-        line-height: 1;
-        }
-    }
-
-.govuk-panel__body {
-    font-size: 19px;
-    line-height: 1.3;
-}
-
-@media (min-width: 40.0625em) {
-.govuk-panel__body {
-  font-size: 24px;
-  line-height: 1.4;
-    }
+  .govuk-panel__body {
+    font-size: 24px;
+    line-height: 1.4;
+  }
 }
 
 .govuk-panel__small {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -59,18 +59,6 @@ $govuk-assets-path: '/govuk/assets/';
   color: $govuk-secondary-text-colour;
 }
 
-// Radio time structure
-.wrapper {
-    display: grid;
-    grid-template-columns: auto auto auto auto;
-}
-@media only screen and (max-width: 600px) {
-    .wrapper {
-        display: grid;
-        grid-template-columns: auto auto;
-    }
-}
-
 // Prototype index page styles
 
 .app-masthead {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -163,45 +163,15 @@ td ul {
     }
 }
 
-
-// Tag modifiers
-// .moj-tag--grey, .moj-tag--green {
-//     border: none;
-// }
 .moj-tag--small--nowrap {
     white-space: nowrap;
     font-size: 0.875rem;
     padding-bottom: 5px;
 }
 
-.moj-badge-wrapper {
-    display: block;
-    margin-bottom: 5px;
-}
-
-.moj-badge-wrapper .moj-badge {
-    margin-right: 5px;
-}
-
-// .moj-badge {
-//     white-space: nowrap;
-// }
-
-
-
 .card .govuk-inset-text {
     border-left: 5px solid #b1b4b6;
     padding: 0 15px;
-}
-
-
-// Filter
-@media (min-width: 48.0625em) {
-    .moj-filter-layout__filter {
-        float: left;
-        margin-right: 40px;
-        max-width: 250px;
-    }
 }
 
 
@@ -302,48 +272,6 @@ td ul {
         line-height: 1.25;
     }
 }
-
-// Match table
-.match-record-table {
-    max-width: 960px;
-}
-
-.govuk-table__cell .govuk-radios__label {
-    padding: 0;
-}
-
-.match-table-radio {
-    width: 5%;
-}
-
-.match-table-radio2 {
-    width: 6%;
-}
-
-.match-table-name {
-    width: 25%;
-}
-
-.match-table-dob {
-    width: 16%;
-}
-
-.match-table-gender {
-    width: 12%;
-}
-
-.match-table-pnc {
-    width: 16%;
-}
-
-.match-table-summary {
-    width: 20%;
-}
-
-.reject-btn {
-    background-color: #dee0e2;
-}
-
 
 // DASHBOARD
 
@@ -479,54 +407,8 @@ a:link {
         display: grid;
         grid-template-columns: auto auto;
     }
-    // #donate {
-    //     justify-content: center;
-    //     align-items: center;
-    //     text-align: center;
-    // }
-    #donate label {
-        padding: 10px;
-    }
-    #donate label span {
-        width: 90%!important;
-    }
 }
 
-
-// Radio styles
-
-#donate label {
-    padding-bottom: 15px;
-}
-
-#donate label span {
-    display: inline-block;
-    text-align: center;
-    cursor: default;
-    box-sizing: border-box;
-    margin: 0em;
-    padding: 6px 7px 2px;
-    border-width: 1px;
-    border-style: solid;
-    border-color: rgb(216, 216, 216) rgb(209, 209, 209) rgb(186, 186, 186);
-    border-image: initial;
-    background-color: #f3f2f1;
-    box-shadow: 0 2px 0 #929191;
-    width: 60%;
-    height: 38px;
-}
-
-#donate label input {
-    position:absolute;
-    top:-20px;
-    visibility: hidden;
-}
-
-#donate input:checked + span {
-    background-color: #00703c;
-    box-shadow: 0 2px 0 #002d18;
-    color: white;
-}
 
 // Overall attendance counts
 
@@ -603,18 +485,6 @@ a:link {
 
 .app-related-items .useful-links>li {
     margin-bottom: 15px !important;
-}
-
-.prototype-index {
-    margin-bottom: 80px;
-}
-
-.prototype-write-up .govuk-heading-s {
-    margin-bottom: 10px;
-}
-
-.prototype-write-up .govuk-grid-column-one-third:first-child {
-    padding-left: 0;
 }
 
 @media (min-width: 641px) {
@@ -803,18 +673,7 @@ tr.system td{
 }
 
 .note-panel ul {
-    margin-top: 0;
-}
-
-/*autocomplete*/
-* {
-  box-sizing: border-box;
-}
-
-body {
-    font-family: "GDS Transport", Arial, sans-serif;
-    font-size: 19px;
-
+  margin-top: 0;
 }
 
 /*the container must be positioned relative:*/
@@ -846,54 +705,6 @@ body {
   background-color: #f3f2f1;
 }
 
-/*screenshots*/
-.image-thumbnail {
-    box-shadow: 0 0 0 0.25rem black;
-    width: 100%;
-  }
-
-  .image-thumbnail-link {
-    padding-bottom: 0;
-  }
-
-  figure {
-    display: grid;
-    grid-gap: 1rem 2rem;
-    grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
-    margin-bottom: 0;
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: 2rem;
-  }
-
-  figure:first-child {
-    margin-top: 20rem;
-    padding-top: 20rem;
-  }
-
-  figcaption {
-    margin-top: 1rem !important;
-  }
-
-  .design-history-image {
-    box-shadow: 0 0 0 0.25rem black;
-    height: auto;
-    width: 75%;
-    margin-right: 0rem;
-    margin-bottom: 2rem;
-    margin-top: 0.25rem;
-  }
-
-  @media (min-width: 40.0625em) {
-    .design-history-image {
-        height: auto;
-        width: 30%;
-        margin-right: 1rem;
-        margin-bottom: 2rem;
-        margin-top: 0.25rem;
-        }
-    }
-
-    .govuk-hint-s {
-        color: #505a5f;
-    }
+.govuk-hint-s {
+  color: #505a5f;
+}

--- a/app/assets/sass/components/_cases-table.scss
+++ b/app/assets/sass/components/_cases-table.scss
@@ -1,0 +1,22 @@
+.app-cases-table td ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 1.4em;
+}
+
+.app-cases-table td ul {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style-type: none;
+}
+
+@media screen and (min-width: 40.0625em) {
+  .app-cases-table .custom-delius-record-width {
+    min-width: 180px;
+  }
+
+  .app-cases-table .custom-defendant-width {
+    min-width: 160px;
+  }
+}

--- a/app/assets/sass/components/_key-details-bar.scss
+++ b/app/assets/sass/components/_key-details-bar.scss
@@ -1,0 +1,72 @@
+// Key details bar
+.key-details-bar {
+    background-color: govuk-colour("blue");
+}
+
+.key-details-bar .key-details-bar__key-details {
+    padding: 20px 0;
+    position: relative;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__name {
+    font-family: "GDS Transport", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 24px;
+    font-size: 1.5rem;
+    line-height: 1.04167;
+    font-weight: 700;
+    line-height: 1.11111;
+    margin-right: 10px;
+    -webkit-margin-start: 0;
+    margin-inline-start: 0;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
+    padding-top: 10px;
+    margin-top: 6px;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__status {
+    font-family: "GDS Transport", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 14px;
+    font-size: 0.875rem;
+    line-height: 1.14286;
+    font-weight: 700;
+    line-height: 1.25;
+    padding: 5px 8px;
+    color: govuk-colour("blue");
+    background-color: #ffffff;
+    letter-spacing: 1px;
+    text-decoration: none;
+    text-transform: uppercase;
+    float: right;
+    margin: 5px 0 0;
+}
+
+.key-details-bar .key-details-bar__key-details * {
+    color: #ffffff;
+}
+
+.key-details-bar_divider {
+    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    margin: 0 15px 0 0;
+    padding: 0 15px 0 0;
+}
+
+@media (min-width: 40.0625em) {
+    .key-details-bar .key-details-bar__key-details .key-details-bar__name {
+        font-size: 1.675rem;
+        line-height: 1.11111;
+    }
+
+    .key-details-bar .key-details-bar__key-details .key-details-bar__status {
+        font-size: 16px;
+        font-size: 1rem;
+        line-height: 1.25;
+    }
+}

--- a/app/assets/sass/components/_time-autocomplete.scss
+++ b/app/assets/sass/components/_time-autocomplete.scss
@@ -1,0 +1,32 @@
+.app-time-autocomplete {
+
+  // the container must be positioned relative
+  .autocomplete {
+    position: relative;
+    display: inline-block;
+  }
+
+  .autocomplete-items {
+    @include govuk-font($size: 19);
+    position: absolute;
+    border: 2px solid govuk-colour("black");
+    border-top: none;
+    z-index: 99;
+    // position the autocomplete items to be the same width as the container
+    top: 100%;
+    left: 0;
+    right: 0;
+  }
+
+  .autocomplete-items div {
+    padding: 8px;
+    cursor: pointer;
+    background-color: govuk-colour("white");
+    border-bottom: 1px solid govuk-colour("mid-grey");
+  }
+
+  // when hovering an item
+  .autocomplete-items div:hover {
+    background-color: govuk-colour("light-grey");
+  }
+}

--- a/app/assets/sass/govuk-page-masthead.scss
+++ b/app/assets/sass/govuk-page-masthead.scss
@@ -1,0 +1,24 @@
+// Prototype index page styles
+.app-masthead {
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: govuk-colour("white");
+  background-color: govuk-colour("blue");
+  margin-top: -20px;
+}
+
+@media (min-width: 40.0625em) {
+  .app-masthead {
+    padding-top: 40px;
+  }
+}
+
+.app-masthead__title,
+.app-masthead__subtitle,
+.app-masthead p {
+  color: govuk-colour("white") !important;
+}
+
+.app-masthead__subtitle {
+  font-weight: normal !important;
+}

--- a/app/assets/sass/max-widths.scss
+++ b/app/assets/sass/max-widths.scss
@@ -1,0 +1,75 @@
+// Container max width
+.govuk-width-container,
+.moj-primary-navigation__container,
+.moj-header__container,
+.key-details-bar .key-details-bar__key-details {
+    max-width: 1220px;
+    margin: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-width-container,
+  .moj-primary-navigation__container,
+  .moj-header__container,
+  .key-details-bar .key-details-bar__key-details {
+    margin: 0 30px;
+  }
+}
+
+@media (min-width: 1020px) {
+  .govuk-width-container,
+  .moj-primary-navigation__container,
+  .moj-header__container,
+  .key-details-bar .key-details-bar__key-details {
+    margin: 0 30px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .govuk-width-container,
+  .moj-primary-navigation__container,
+  .moj-header__container,
+  .key-details-bar .key-details-bar__key-details {
+    margin: 0 auto;
+  }
+}
+
+// Element max width
+.govuk-heading-s,
+.govuk-heading-m,
+.govuk-heading-l,
+.govuk-heading-xl,
+.govuk-body,
+.govuk-body-l,
+.govuk-body-s,
+.govuk-caption-m,
+.govuk-caption-l,
+.govuk-caption-xl,
+.govuk-link,
+.govuk-list,
+.govuk-label,
+.govuk-hint,
+.govuk-fieldset__legend,
+.govuk-fieldset__heading,
+.govuk-accordion__section-heading,
+.govuk-textarea,
+.govuk-details__summary,
+.govuk-details__text,
+.govuk-error-message,
+.govuk-error-summary__title,
+.govuk-inset-text,
+.govuk-panel__title,
+.govuk-panel__body,
+.govuk-warning-text__text,
+.govuk-phase-banner__content,
+.govuk-select,
+.govuk-table__caption,
+.govuk-summary-list,
+.govuk-accordion,
+.govuk-table {
+  max-width: 727px;
+}
+
+.govuk-table-xl {
+  max-width: none;
+}

--- a/app/views/arrange-a-session/when.html
+++ b/app/views/arrange-a-session/when.html
@@ -47,7 +47,7 @@
     </fieldset>
   </div>
 
-  <div class="govuk-form-group">
+  <div class="govuk-form-group app-time-autocomplete">
     <div class="autocomplete">
       <label class="govuk-label govuk-!-font-weight-bold" for="session-start-time">
         Time

--- a/app/views/includes/case-list-data.html
+++ b/app/views/includes/case-list-data.html
@@ -1,7 +1,7 @@
 <div class="moj-scrollable-pane">
   <div class="moj-scrollable-pane__wrapper">
 
-    <table class="govuk-table govuk-table-xl">
+    <table class="govuk-table govuk-table-xl app-cases-table">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row govuk-table__row">
           <th scope="col" class="govuk-table__header custom-defendant-width" aria-sort="none">Service user</th>


### PR DESCRIPTION
- Remove any unused styles
- Move groups of styles into separate files (components or otherwise)
- Remove dangerously generic style rules that could accidentally apply in unintended places
- Begin using govuk-frontend variables rather than hardcoded colours and fonts