### PR TITLE
Update key details banner layout

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -76,3 +76,47 @@ $govuk-assets-path: '/govuk/assets/';
 .govuk-hint-s {
   color: govuk-colour("dark-grey");
 }
+
+.app-card__meta-list {
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  width: 100%;
+  margin: 0 0 20px;
+}
+
+.app-card__meta-list-item {
+  margin-bottom: 10px;
+}
+
+.app-card__meta-list-key, .app-card__meta-list-value {
+  display: block;
+}
+
+.app-card__meta-list-key {
+  font-weight: 700;
+}
+
+.app-card__meta-list-value {
+  margin: 0;
+}
+
+@media (min-width: 48.0625em) {
+.app-card__meta-list {
+    display: grid;
+    grid-template-columns: repeat(5,1fr);
+    grid-gap: 15px;
+  } 
+}
+
+@media (min-width: 40.0625em) {
+.app-card__meta-list {
+    font-size: 19px;
+    line-height: 1.5;
+
+  }
+}
+

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -22,6 +22,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/key-details-bar";
 @import "components/time-autocomplete";
 @import "components/cases-table";
+@import "components/app-card-meta-list";
 
 @import 'accessible-autocomplete.min';
 // @import 'max-widths';
@@ -76,47 +77,3 @@ $govuk-assets-path: '/govuk/assets/';
 .govuk-hint-s {
   color: govuk-colour("dark-grey");
 }
-
-.app-card__meta-list {
-  font-family: "GDS Transport", Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 1.25;
-  width: 100%;
-  margin: 0 0 20px;
-}
-
-.app-card__meta-list-item {
-  margin-bottom: 10px;
-}
-
-.app-card__meta-list-key, .app-card__meta-list-value {
-  display: block;
-}
-
-.app-card__meta-list-key {
-  font-weight: 700;
-}
-
-.app-card__meta-list-value {
-  margin: 0;
-}
-
-@media (min-width: 48.0625em) {
-.app-card__meta-list {
-    display: grid;
-    grid-template-columns: repeat(5,1fr);
-    grid-gap: 15px;
-  } 
-}
-
-@media (min-width: 40.0625em) {
-.app-card__meta-list {
-    font-size: 19px;
-    line-height: 1.5;
-
-  }
-}
-

--- a/app/assets/sass/components/_app-card-meta-list.scss
+++ b/app/assets/sass/components/_app-card-meta-list.scss
@@ -1,0 +1,42 @@
+.app-card__meta-list {
+    font-family: "GDS Transport", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 1.25;
+    width: 100%;
+    margin: 0 0 20px;
+  }
+  
+  .app-card__meta-list-item {
+    margin-bottom: 10px;
+  }
+  
+  .app-card__meta-list-key, .app-card__meta-list-value {
+    display: block;
+  }
+  
+  .app-card__meta-list-key {
+    font-weight: 700;
+  }
+  
+  .app-card__meta-list-value {
+    margin: 0;
+  }
+  
+  @media (min-width: 48.0625em) {
+  .app-card__meta-list {
+      display: grid;
+      grid-template-columns: repeat(5,1fr);
+      grid-gap: 15px;
+    } 
+  }
+  
+  @media (min-width: 40.0625em) {
+  .app-card__meta-list {
+      font-size: 19px;
+      line-height: 1.5;
+  
+    }
+  }

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -8,25 +8,30 @@
   <span class="govuk-tag govuk-tag--red">Risk to children</span>
 </p>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    {{ govukSummaryList({
-      classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: { text: "CRN" },
-          value: { text: CRN }
-        },
-        {
-          key: { text: "PNC" },
-          value: { text: case.PNC }
-        },
-        {
-          key: { text: "Date of birth" },
-          value: { text: case.serviceUserPersonalDetails.dateOfBirth | dateWithYear + " (" + yearsSince(case.serviceUserPersonalDetails.dateOfBirth) + " years old)" }
-        }
-      ]
-    }) }}
+<dl class="app-card__meta-list">
+  <div class="app-card__meta-list-item">
+    <dt class="app-card__meta-list-key">
+      CRN
+    </dt>
+    <dd class="app-card__meta-list-value">
+      J678910
+    </dd>
   </div>
-</div>
+  <div class="app-card__meta-list-item">
+    <dt class="app-card__meta-list-key">
+      PNC
+    </dt>
+    <dd class="app-card__meta-list-value">
+      2012/123400000F
+    </dd>
+  </div>
+  <div class="app-card__meta-list-item">
+    <dt class="app-card__meta-list-key">
+      Date of birth
+    </dt>
+    <dd class="app-card__meta-list-value">
+      27 Sep 1984 (Age 36)
+    </dd>
+  </div>
+</dl>
+

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -14,7 +14,7 @@
       CRN
     </dt>
     <dd class="app-card__meta-list-value">
-      J678910
+      {{ CRN }} 
     </dd>
   </div>
   <div class="app-card__meta-list-item">
@@ -22,7 +22,7 @@
       PNC
     </dt>
     <dd class="app-card__meta-list-value">
-      2012/123400000F
+      {{ case.PNC }}
     </dd>
   </div>
   <div class="app-card__meta-list-item">
@@ -30,7 +30,7 @@
       Date of birth
     </dt>
     <dd class="app-card__meta-list-value">
-      27 Sep 1984 (Age 36)
+      {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear + " (" + yearsSince(case.serviceUserPersonalDetails.dateOfBirth) + " years old)" }}
     </dd>
   </div>
 </dl>

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -30,7 +30,7 @@
       Date of birth
     </dt>
     <dd class="app-card__meta-list-value">
-      {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear + " (" + yearsSince(case.serviceUserPersonalDetails.dateOfBirth) + " years old)" }}
+      {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYearShortMonth + " (age " + yearsSince(case.serviceUserPersonalDetails.dateOfBirth) + ")" }}
     </dd>
   </div>
 </dl>


### PR DESCRIPTION
The height of the key details banner has been reduced. 

The layout change has been taken from digital products in prison. 

Before:
![Screenshot 2021-04-14 at 14 25 28](https://user-images.githubusercontent.com/6122118/114717831-5cbe5a00-9d2d-11eb-8229-0ef48c86402f.png)

After:
![Screenshot 2021-04-14 at 14 25 33](https://user-images.githubusercontent.com/6122118/114717859-647dfe80-9d2d-11eb-8ddf-57d0969964c5.png)
