### PR TITLE
Unify how 'confirm attendance' and 'arrange an appointment' data is stored (part 1)

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -213,7 +213,7 @@ module.exports = [
       'timestamp': helpers.yesterdayAt('13:00'),
       'endTime': helpers.yesterdayAt('14:00'),
       'type': 'Office visit',
-      'countsTowardsRAR': true,
+      'countsTowardsRAR': 'Yes',
       'RARCategory': 'Thinking skills, attitudes and behaviour',
       'sessionId': 456
     },

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -204,17 +204,16 @@ module.exports = [
     ],
     'status': 'Previously known',
     'previousOrderStatus': 'Order ended 24 Nov 2016',
-    'nextAppointment': {
-      'timestamp': helpers.tomorrowAt('13:00'),
-      'endTime': helpers.tomorrowAt('14:00'),
-      'type': 'Office visit'
-    },
     'previousAppointment': {
-      'timestamp': helpers.yesterdayAt('13:00'),
-      'endTime': helpers.yesterdayAt('14:00'),
-      'type': 'Office visit',
-      'countsTowardsRAR': 'Yes',
-      'RARCategory': 'Thinking skills, attitudes and behaviour',
+      'session-date': helpers.yesterday(),
+      'session-counts-towards-rar': 'Yes',
+      'session-start-time': '1pm',
+      'session-end-time': '2pm',
+      'session-counts-towards-rar': 'Yes',
+      'session-rar-category': 'Thinking skills, attitudes and behaviour',
+      'type-of-session': 'Office visit',
+      'repeating': 'No, it’s a one-off session',
+      'confirmed': true,
       'sessionId': 456
     },
     'appointmentStatistics': {
@@ -226,7 +225,7 @@ module.exports = [
       {
         'type': 'Office visit',
         'probationPractitioner': 'Mark Berridge',
-        'timestamp': helpers.yesterdayAt('13:00'),
+        'timestamp': helpers.yesterday({atTime: '13:00'}),
         'sessionId': 456,
         'outcome': null
       },
@@ -318,11 +317,6 @@ module.exports = [
     'riskOfSeriousHarmLevel': {
       text: 'Medium',
       class: 'orange'
-    },
-    'nextAppointment': {
-      'timestamp': '2020-12-07T09:30',
-      'endTime': '2020-12-07T10:30',
-      'type': 'Office visit'
     }
   },
   {
@@ -336,7 +330,6 @@ module.exports = [
     'riskOfSeriousHarmLevel': {
       text: 'High',
       class: 'red'
-    },
-    'nextAppointment': null
+    }
   }
 ]

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -4,12 +4,9 @@ const helpers = require(path.join(__dirname, '../../lib/helpers.js'))
 
 const confirmAttendanceDefaults = (map, su) => {
   if (su.previousAppointment) {
-    var defaults = {}
-    defaults[su.previousAppointment.sessionId] = {
-      'countsTowardsRAR': su.previousAppointment.countsTowardsRAR ? 'Yes' : 'No',
-      'RARCategory': su.previousAppointment.RARCategory
+    map[su.CRN] = {
+      [su.previousAppointment.sessionId]: su.previousAppointment
     }
-    map[su.CRN] = defaults
   }
   return map
 }

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -55,7 +55,7 @@
   <p class="govuk-body">You’re confirming attendance for:</p>
 
   <div class="govuk-inset-text">
-    <strong>{{ case.previousAppointment.type }}</strong><br>
-    {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
+    <strong>{{ data['confirm-attendance'][CRN][sessionId].type }}</strong><br>
+    {{ data['confirm-attendance'][CRN][sessionId].timestamp | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId].timestamp | govukTime }} to {{ data['confirm-attendance'][CRN][sessionId].endTime | govukTime }}
   </div>
 {% endblock %}

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -12,7 +12,7 @@
     rows: [
       {
         key: { text: "RAR activity" },
-        value: { text: data['confirm-attendance'][CRN][sessionId]['RARCategory'] if data['confirm-attendance'][CRN][sessionId]['countsTowardsRAR'] == 'Yes' else 'None'  },
+        value: { text: data['confirm-attendance'][CRN][sessionId]['session-rar-category'] if data['confirm-attendance'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes' else 'None'  },
         actions: {
           items: [
             {
@@ -55,7 +55,7 @@
   <p class="govuk-body">You’re confirming attendance for:</p>
 
   <div class="govuk-inset-text">
-    <strong>{{ data['confirm-attendance'][CRN][sessionId].type }}</strong><br>
-    {{ data['confirm-attendance'][CRN][sessionId].timestamp | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId].timestamp | govukTime }} to {{ data['confirm-attendance'][CRN][sessionId].endTime | govukTime }}
+    <strong>{{ data['confirm-attendance'][CRN][sessionId]['type-of-session'] }}</strong><br>
+    {{ data['confirm-attendance'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId]['session-start-time'] }} to {{ data['confirm-attendance'][CRN][sessionId]['session-end-time'] }}
   </div>
 {% endblock %}

--- a/app/views/confirm-attendance/confirmation.html
+++ b/app/views/confirm-attendance/confirmation.html
@@ -5,8 +5,8 @@
 {% block page %}
 
   {% set panelHtml %}
-    <strong>{{ data['confirm-attendance'][CRN][sessionId].type }}</strong><br>
-    {{ data['confirm-attendance'][CRN][sessionId].timestamp | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId].timestamp | govukTime }} to {{ data['confirm-attendance'][CRN][sessionId].endTime | govukTime }}
+    <strong>{{ data['confirm-attendance'][CRN][sessionId]['type-of-session'] }}</strong><br>
+    {{ data['confirm-attendance'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId]['session-start-time'] }} to {{ data['confirm-attendance'][CRN][sessionId]['session-end-time'] }}
   {% endset %}
 
   {{ govukPanel({

--- a/app/views/confirm-attendance/confirmation.html
+++ b/app/views/confirm-attendance/confirmation.html
@@ -5,8 +5,8 @@
 {% block page %}
 
   {% set panelHtml %}
-    <strong>{{ case.previousAppointment.type }}</strong><br>
-    {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
+    <strong>{{ data['confirm-attendance'][CRN][sessionId].type }}</strong><br>
+    {{ data['confirm-attendance'][CRN][sessionId].timestamp | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId].timestamp | govukTime }} to {{ data['confirm-attendance'][CRN][sessionId].endTime | govukTime }}
   {% endset %}
 
   {{ govukPanel({

--- a/app/views/confirm-attendance/rar-categories.html
+++ b/app/views/confirm-attendance/rar-categories.html
@@ -18,8 +18,7 @@
   {% for rarCategory in rarCategories %}
     {% set rarRadioItems = (rarRadioItems.push({
       text: rarCategory,
-      value: rarCategory,
-      checked: checked("session-rar-category", rarCategory)
+      value: rarCategory
     }), rarRadioItems) %}
   {% endfor %}
 
@@ -31,7 +30,7 @@
              }
            },
            items: rarRadioItems
-         } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'RARCategory']) )
+         } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'session-rar-category']) )
       }}
   {% endset %}
 
@@ -59,5 +58,5 @@
            value: 'No'
          }
        ]
-       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'countsTowardsRAR']) ) }}
+       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'session-counts-towards-rar']) ) }}
 {% endblock %}

--- a/app/views/confirm-attendance/start.html
+++ b/app/views/confirm-attendance/start.html
@@ -7,7 +7,7 @@
   <p class="govuk-body">You’re confirming attendance for:</p>
 
   <div class="govuk-inset-text">
-    <strong>{{ data['confirm-attendance'][CRN][sessionId].type }}</strong><br>
-    {{ data['confirm-attendance'][CRN][sessionId].timestamp | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId].startTime }} to {{ data['confirm-attendance'][CRN][sessionId].endTime | govukTime }}
+    <strong>{{ data['confirm-attendance'][CRN][sessionId]['type-of-session'] }}</strong><br>
+    {{ data['confirm-attendance'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId]['session-start-time'] }} to {{ data['confirm-attendance'][CRN][sessionId]['session-end-time'] }}
   </div>
 {% endblock %}

--- a/app/views/confirm-attendance/start.html
+++ b/app/views/confirm-attendance/start.html
@@ -7,7 +7,7 @@
   <p class="govuk-body">You’re confirming attendance for:</p>
 
   <div class="govuk-inset-text">
-    <strong>{{ case.previousAppointment.type }}</strong><br>
-    {{ case.previousAppointment.timestamp | dateWithDayAndWithoutYear }} from {{ case.previousAppointment.timestamp | govukTime }} to {{ case.previousAppointment.endTime | govukTime }}
+    <strong>{{ data['confirm-attendance'][CRN][sessionId].type }}</strong><br>
+    {{ data['confirm-attendance'][CRN][sessionId].timestamp | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId].startTime }} to {{ data['confirm-attendance'][CRN][sessionId].endTime | govukTime }}
   </div>
 {% endblock %}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -39,8 +39,8 @@ exports.tomorrowAt = (time) => {
   return exports.happeningIn({daysLater: 1, atTime: time})
 }
 
-exports.yesterdayAt = (time) => {
-  return exports.happeningIn({daysLater: -1, atTime: time})
+exports.yesterday = (params = {}) => {
+  return exports.happeningIn({daysLater: -1, atTime: params.atTime})
 }
 
 exports.yearsSince = (time) => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -31,12 +31,12 @@ exports.happeningIn = (params) => {
   return DateTime.now().plusBusiness({days: params.daysLater}).toISODate() + (params.atTime ? 'T' + params.atTime : '')
 }
 
-exports.todayAt = (time) => {
-  return exports.happeningIn({daysLater: 0, atTime: time})
+exports.today = (params = {}) => {
+  return exports.happeningIn({daysLater: 0, params.atTime})
 }
 
-exports.tomorrowAt = (time) => {
-  return exports.happeningIn({daysLater: 1, atTime: time})
+exports.tomorrow = (params = {}) => {
+  return exports.happeningIn({daysLater: 1, atTime: params.atTime})
 }
 
 exports.yesterday = (params = {}) => {


### PR DESCRIPTION
This is a step towards having fully consistent data in the prototype.