### PR TITLE
Update styling of definition list

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -23,6 +23,7 @@ $govuk-assets-path: '/govuk/assets/';
 @import "components/time-autocomplete";
 @import "components/cases-table";
 @import "components/app-card-meta-list";
+@import "components/app-card-one-third-column-list";
 
 @import 'accessible-autocomplete.min';
 // @import 'max-widths';

--- a/app/assets/sass/components/_app-card-one-third-column-list.scss
+++ b/app/assets/sass/components/_app-card-one-third-column-list.scss
@@ -1,0 +1,36 @@
+.app-card__one-third-column-list {
+    font-family: "GDS Transport", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 1.25;
+    width: 100%;
+    margin: 0 0 20px;
+  }
+  
+  .app-card__one-third-column-list-item {
+    margin-bottom: 10px;
+  }
+  
+  .app-card__one-third-column-list-key, .app-card__one-third-column-list-value {
+    display: block;
+  }
+  
+  .app-card__one-third-column-list-key {
+    font-weight: 700;
+  }
+  
+  .app-card__one-third-column-list-value {
+    margin: 0;
+  }
+  
+
+  
+  @media (min-width: 40.0625em) {
+  .app-card__one-third-column-list {
+      font-size: 19px;
+      line-height: 1.5;
+  
+    }
+  }

--- a/app/views/case/details.html
+++ b/app/views/case/details.html
@@ -42,11 +42,11 @@
       ]
       }) }}
 
+      {% if case.personalContacts.length > 0 %}
       <p class="govuk-body">
-        <a href="/cases/{{ CRN }}/address-book-personal">
-          View address book
-        </a>
+        <a href="/cases/{{ CRN }}/address-book-personal">View all personal contacts ({{ case.personalContacts.length }})</a>
       </p>
+    {% endif %}
       <p class="govuk-body-s govuk-hint-s">
         Last updated 15 March 2021
       </p>
@@ -92,7 +92,7 @@
 
       <p class="govuk-body">
         <a href="personal-details">
-          View more personal details
+          View all personal details
         </a>
       </p>
       <p class="govuk-body-s govuk-hint-s">
@@ -127,7 +127,7 @@
 
       <p class="govuk-body">
         <a href="#">
-          View more circumstances
+          View all circumstances
         </a>
       </p>
       <p class="govuk-body-s govuk-hint-s">

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -89,28 +89,6 @@
       <a href="#">View sentence plan</a>
     </p>
 
-    <h2 class="govuk-heading-m">
-      Recent communication
-    </h2>
-
-    {% set hr = joiner('<hr>') %}
-    {% for entry in case.contactHistory %}
-      {% if loop.index <= 3 %}
-        {{ hr() | safe }}
-
-        {% if entry.type === 'Appointment' %}
-          {% include "case/_appointment-timeline-entry.html" %}
-        {% elseif entry.type === 'Text message' or entry.type === 'Email' %}
-          {% include "case/_communcation-timeline-entry.html" %}
-        {% endif %}
-
-        <p class="govuk-body-s govuk-hint-s">Last updated by {{ entry.lastUpdatedBy }} on {{ entry.timestamp | dateWithYear }} at {{ entry.timestamp | govukTimeWithMinutes }}</p>
-      {% endif %}
-    {% endfor %}
-
-    <p>
-      <a href="/cases/{{ CRN }}/communication">View all communication</a>
-    </p>
   </div>
 
   <div class="govuk-grid-column-one-third">
@@ -141,7 +119,7 @@
     </div>
 
     <h2 class="govuk-heading-m">
-      Attendance
+      Appointment attendance
     </h2>
 
     <p class="govuk-body">
@@ -162,57 +140,94 @@
       Contact details
     </h2>
 
-    {{ govukSummaryList({
-      classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: { text: "Address" },
-          value: { html: case.serviceUserPersonalDetails.address.join('<br>') }
-        },
-        {
-          key: { text: "Phone number" },
-          value: { text: case.serviceUserPersonalDetails.phone }
-        },
-        {
-          key: { text: "Email" },
-          value: { text: case.serviceUserPersonalDetails.email }
-        }
-      ]
-    }) }}
+    <dl class="app-card__one-third-column-list">
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Address
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.address.join('<br>') | safe }}
+        </dd>
+      </div>
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Phone number
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.phone }}
+        </dd>
+      </div>
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Email
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.email }}
+        </dd>
+      </div>
+    </dl>
 
+    {% if case.personalContacts.length > 0 %}
     <p class="govuk-body">
-      <a href="/cases/{{ CRN }}/address-book-personal">View address book</a>
+      <a class="govuk-heading-s" href="/cases/{{ CRN }}/address-book-personal">View all personal contacts ({{ case.personalContacts.length }})</a>
     </p>
+  {% endif %}
 
     <h2 class="govuk-heading-m">
       Personal details and circumstances
     </h2>
 
-    {{ govukSummaryList({
-      classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: { text: "Preferred language" },
-          value: { text: case.serviceUserPersonalDetails.preferredLanguage }
-        },
-        {
-          key: { text: "Disabilities and adjustments" },
-          value: { text: case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }
-        },
-        {
-          key: { text: "Employment status" },
-          value: { text: case.serviceUserPersonalDetails.circumstances.employment }
-        },
-        {
-          key: { text: "Housing status" },
-          value: { text: case.serviceUserPersonalDetails.circumstances.housingStatus }
-        }
-      ]
-      }) }}
+    <dl class="app-card__one-third-column-list">
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Preferred language
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.preferredLanguage }}
+        </dd>
+      </div>
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Disabilities and adjustments
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments }}
+        </dd>
+      </div>
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Employment status
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.circumstances.employment }}
+        </dd>
+      </div>
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Housing status
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.circumstances.housingStatus }}
+        </dd>
+      </div>
+      <div class="app-card__one-third-column-list-item">
+        <dt class="app-card__one-third-column-list-key">
+          Safeguarding issues
+        </dt>
+        <dd class="app-card__one-third-column-list-value">
+          {{ case.serviceUserPersonalDetails.circumstances.safeguardingIssues.join(', ') or 'None' }}
+        </dd>
+      </div>
+    </dl>
 
     <h2 class="govuk-heading-m">
       Probation history
     </h2>
+
+    <div class="app-card app-card--blue govuk-!-margin-bottom-6">
+      <strong>Probation status</strong><br>
+      {{ case.status }}
+    </div>
 
     <p class="govuk-body">
       <ul class="govuk-list">
@@ -227,10 +242,7 @@
 
     {% if case.previousOrders.length > 0 %}
       <p class="govuk-body">
-        <a class="govuk-heading-s" href="/cases/{{ CRN }}/previous-orders">Previous orders ({{ case.previousOrders.length }})</a>
-      </p>
-
-      <p class="govuk-body">
+        <a class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1" href="/cases/{{ CRN }}/previous-orders">Previous orders ({{ case.previousOrders.length }})</a>
         Last ended on {{ case.previousOrders[0].endDate | dateWithYearShortMonth }}
       </p>
     {% endif %}
@@ -241,9 +253,6 @@
       </p>
     {% endif %}
 
-    <p class="govuk-body">
-      <a href="/cases/{{ CRN }}/previous-orders">View full probation history</a>
-    </p>
   </div>
 </div>
 

--- a/app/views/case/sentence.html
+++ b/app/views/case/sentence.html
@@ -48,6 +48,14 @@
             {{ case.currentOrder.endDate | dateWithYear }}
           </dd>
         </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Time elapsed
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ case.currentOrder.progressInMonths }} months elapsed (of {{ case.currentOrder.lengthInMonths }} months)
+          </dd>
+        </div>
         </dl>
       </div>
 
@@ -130,22 +138,39 @@
       </div>
     </div>
 
-    <h2 class="govuk-heading-m">History</h2>
+    <h2 class="govuk-heading-m">
+      Probation history
+    </h2>
+
     <div class="app-card app-card--blue govuk-!-margin-bottom-6">
       <strong>Probation status</strong><br>
       {{ case.status }}
     </div>
 
     <p class="govuk-body">
-      <a href="previous-orders" class="govuk-!-font-weight-bold">
-        Previous orders
-      </a>
+      <ul class="govuk-list">
+        <li>
+          <span class="govuk-tag govuk-tag--grey">{{ case.breachesCount }}</span> Breaches
+        </li>
+        <li>
+          <span class="govuk-tag govuk-tag--grey">{{ case.restrainingOrdersCount }}</span> Restraining orders
+        </li>
+      </ul>
     </p>
+
+    {% if case.previousOrders.length > 0 %}
     <p class="govuk-body">
-      <a href="address-book-professional" class="govuk-!-font-weight-bold">
-        Address book
-      </a>
+      <a class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1" href="/cases/{{ CRN }}/previous-orders">Previous orders ({{ case.previousOrders.length }})</a>
+      Last ended on {{ case.previousOrders[0].endDate | dateWithYearShortMonth }}
     </p>
+    {% endif %}
+
+    {% if case.professionalContacts.length > 0 %}
+      <p class="govuk-body">
+        <a class="govuk-heading-s" href="/cases/{{ CRN }}/address-book-professional">Previous professional contacts ({{ case.professionalContacts.length }})</a>
+      </p>
+    {% endif %}
+
   </div>
 </div>
 


### PR DESCRIPTION
- Update the definition lists on the Quick look page:

Before:
![Screenshot 2021-04-15 at 15 28 00](https://user-images.githubusercontent.com/6122118/114886293-54ceea80-9dff-11eb-9471-fd22784d509a.png)

After:
![Screenshot 2021-04-15 at 15 27 49](https://user-images.githubusercontent.com/6122118/114886262-4ed90980-9dff-11eb-942d-00cb4be01563.png)

- Removed Recent communication from the Quick look page

- Added Probation status to Quick look page

![Screenshot 2021-04-15 at 15 30 32](https://user-images.githubusercontent.com/6122118/114886587-919ae180-9dff-11eb-9949-f4647bb7a8e4.png)

- Content tweaks to Quick look, Personal details and Sentence pages for consistency.

