### PR TITLE
Unify the data in the prototype, make it persist between transactions

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -224,6 +224,21 @@ module.exports = [
     'contactHistory': [
       {
         'type': 'Appointment',
+        'timestamp': helpers.happeningIn({ daysLater: 5, atTime: '11:00' }),
+        'session-date': helpers.happeningIn({ daysLater: 5 }),
+        'session-end-time': '11am',
+        'session-start-time': '10am',
+        'session-counts-towards-rar': 'Yes',
+        'session-rar-category': 'ES - Accommodation LDN',
+        'session-rar-subcategory': 'Accommodation (Custody Transition)',
+        'type-of-session': 'Home visit',
+        'repeating': 'No, it’s a one-off session',
+        'confirmed': true,
+        'lastUpdatedBy': 'Mark Berridge',
+        'sessionId': 123
+      },
+      {
+        'type': 'Appointment',
         'type-of-session': 'Office visit',
         'lastUpdatedBy': 'Mark Berridge',
         'timestamp': helpers.yesterday({atTime: '13:00'}),

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -235,7 +235,6 @@ module.exports = [
         'session-rar-category': 'Relationships',
         'session-notes': 'Will use this time to catch up on Dylan’s relationships homework.',
         'sessionId': 456,
-        'outcome': null
       },
       {
         'lastUpdatedBy': 'Mark Berridge',

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -234,7 +234,7 @@ module.exports = [
         'session-counts-towards-rar': 'Yes',
         'session-rar-category': 'Relationships',
         'session-notes': 'Will use this time to catch up on Dylan’s relationships homework.',
-        'sessionId': 456,
+        'sessionId': 456
       },
       {
         'lastUpdatedBy': 'Mark Berridge',
@@ -242,7 +242,8 @@ module.exports = [
         'from': 'Service user',
         'to': 'Mark Berridge',
         'timestamp': '2021-04-22T13:00',
-        'contents': 'Hi Mark, got the email. I’ll be there. D.'
+        'contents': 'Hi Mark, got the email. I’ll be there. D.',
+        'sessionId': 987
       },
       {
         'lastUpdatedBy': 'Mark Berridge',
@@ -252,7 +253,8 @@ module.exports = [
         'timestamp': '2021-04-10T13:00',
         'contents': `Hi Dylan,
 
-        It’s really important that you come back in to see me. I understand that my last letter was sent to your old room so I’m trying you on the email address you provided me. We talked at the beginning of your probation about what might happen if you refuse to comply...`
+        It’s really important that you come back in to see me. I understand that my last letter was sent to your old room so I’m trying you on the email address you provided me. We talked at the beginning of your probation about what might happen if you refuse to comply...`,
+        'sessionId': 986
       },
       {
         'lastUpdatedBy': 'Mark Berridge',
@@ -265,7 +267,8 @@ module.exports = [
         I’m writing to enquire after Dylan and confirm he is settled in his new room? I have written to him about his non compliance in our last meeting and need to confirm that the letter has reached him?
 
         Cheers,
-        Mark`
+        Mark`,
+        'sessionId': 985
       },
       {
         'type': 'Appointment',
@@ -279,7 +282,8 @@ module.exports = [
         'did-service-user-comply': 'No',
         'repeating': 'No, it’s a one-off session',
         'confirmed': true,
-        'session-notes': 'Dylan turned up for his appointment on time however he refused to talk about anything with me until “his new room was sorted out” I explained it wasn’t possible to move him until the 19th to which he stormed out of the meeting.'
+        'session-notes': 'Dylan turned up for his appointment on time however he refused to talk about anything with me until “his new room was sorted out” I explained it wasn’t possible to move him until the 19th to which he stormed out of the meeting.',
+        'sessionId': 984
       },
       {
         'lastUpdatedBy': 'Mark Berridge',
@@ -292,7 +296,8 @@ module.exports = [
         Thanks for your email, I’ve received Dylan’s request and we have a room available on the ground floor coming available on the 19th of March.
 
         All the best,
-        Jane`
+        Jane`,
+        'sessionId': 983
       },
       {
         'lastUpdatedBy': 'Mark Berridge',
@@ -305,7 +310,8 @@ module.exports = [
         I’m writing to confirm that you have received my application on behalf of Dylan to change the room he has been allocated at the hostel. He now has part time work with very early shifts and is struggling with some of the noisier occupants on his floor.
 
         Thanks in advance,
-        Mark`
+        Mark`,
+        'sessionId': 982
       },
       {
         'type': 'Appointment',
@@ -317,7 +323,8 @@ module.exports = [
         'session-counts-towards-rar': 'No',
         'type-of-session': 'Office visit',
         'did-service-user-comply': 'Yes',
-        'session-notes': 'Dylan arrived on time and presented well for his induction appointment. He filled in all the paperwork required without any resistance and said he understood the process. He mentioned his mum had talked to him a lot over the weekend and helped him to calm down. His mum appears to be a positive influence in his life, which I would like to explore further with him.'
+        'session-notes': 'Dylan arrived on time and presented well for his induction appointment. He filled in all the paperwork required without any resistance and said he understood the process. He mentioned his mum had talked to him a lot over the weekend and helped him to calm down. His mum appears to be a positive influence in his life, which I would like to explore further with him.',
+        'sessionId': 981
       },
       {
         'type': 'Appointment',
@@ -329,7 +336,8 @@ module.exports = [
         'session-end-time': '2pm',
         'session-counts-towards-rar': 'No',
         'did-service-user-comply': 'No',
-        'session-notes': 'I called Dylan to confirm he had understood where he needed to be and when for his induction appointment. He was rude and abusive and in general very hostile in reaction to his sentence saying this wasn’t his fault. He mentioned he “doesn’t have time for this”. I reiterated that he must be at the office on Monday as part of his sentence requirements and if he doesn’t it’s going to reflect very poorly.'
+        'session-notes': 'I called Dylan to confirm he had understood where he needed to be and when for his induction appointment. He was rude and abusive and in general very hostile in reaction to his sentence saying this wasn’t his fault. He mentioned he “doesn’t have time for this”. I reiterated that he must be at the office on Monday as part of his sentence requirements and if he doesn’t it’s going to reflect very poorly.',
+        'sessionId': 980
       }
     ]
   },

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -241,7 +241,7 @@ module.exports = [
         'type': 'Text message',
         'from': 'Service user',
         'to': 'Mark Berridge',
-        'timestamp': '2021-04-22T13:00',
+        'timestamp': '2021-04-11T13:00',
         'contents': 'Hi Mark, got the email. I’ll be there. D.',
         'sessionId': 987
       },

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -204,18 +204,6 @@ module.exports = [
     ],
     'status': 'Previously known',
     'previousOrderStatus': 'Order ended 24 Nov 2016',
-    'previousAppointment': {
-      'session-date': helpers.yesterday(),
-      'session-counts-towards-rar': 'Yes',
-      'session-start-time': '1pm',
-      'session-end-time': '2pm',
-      'session-counts-towards-rar': 'Yes',
-      'session-rar-category': 'Thinking skills, attitudes and behaviour',
-      'type-of-session': 'Office visit',
-      'repeating': 'No, it’s a one-off session',
-      'confirmed': true,
-      'sessionId': 456
-    },
     'appointmentStatistics': {
       'complied': 5,
       'acceptableAbsence': 1,

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -367,7 +367,8 @@ module.exports = [
     'riskOfSeriousHarmLevel': {
       text: 'Medium',
       class: 'orange'
-    }
+    },
+    'contactHistory': []
   },
   {
     'serviceUserPersonalDetails': {
@@ -380,6 +381,7 @@ module.exports = [
     'riskOfSeriousHarmLevel': {
       text: 'High',
       class: 'red'
-    }
+    },
+    'contactHistory': []
   }
 ]

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -2,15 +2,6 @@ const path = require('path')
 const cases = require('./cases')
 const helpers = require(path.join(__dirname, '../../lib/helpers.js'))
 
-const confirmAttendanceDefaults = (map, su) => {
-  if (su.previousAppointment && su.previousAppointment.sessionId) {
-    map[su.CRN] = {
-      [su.previousAppointment.sessionId]: su.previousAppointment
-    }
-  }
-  return map
-}
-
 const contactHistoryDefaults = (map, su) => {
   if (su.contactHistory) {
     map[su.CRN] = su.contactHistory.reduce((o, contact) => ({ ...o, [contact.sessionId]: contact}), {})
@@ -27,7 +18,6 @@ module.exports = {
   'team-codes': ['C17ETE'],
   cases: cases,
   'communication': cases.reduce(contactHistoryDefaults, {}),
-  'confirm-attendance': cases.reduce(confirmAttendanceDefaults, {}),
   'arrange-a-session': {
     'J678910': {
       123: cases

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -17,13 +17,5 @@ module.exports = {
   },
   'team-codes': ['C17ETE'],
   cases: cases,
-  'communication': cases.reduce(contactHistoryDefaults, {}),
-  'arrange-a-session': {
-    'J678910': {
-      123: cases
-        .find(entry => entry.CRN === 'J678910')
-        .contactHistory
-        .find(entry => entry.sessionId === 123)
-    }
-  }
+  'communication': cases.reduce(contactHistoryDefaults, {})
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -23,6 +23,7 @@ module.exports = {
   'arrange-a-session': {
     'J678910': {
       123: {
+        'type': 'Appointment',
         'session-date': helpers.happeningIn({ daysLater: 5 }),
         'session-end-time': '11am',
         'session-start-time': '10am',

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -30,18 +30,10 @@ module.exports = {
   'confirm-attendance': cases.reduce(confirmAttendanceDefaults, {}),
   'arrange-a-session': {
     'J678910': {
-      123: {
-        'type': 'Appointment',
-        'session-date': helpers.happeningIn({ daysLater: 5 }),
-        'session-end-time': '11am',
-        'session-start-time': '10am',
-        'session-counts-towards-rar': 'Yes',
-        'session-rar-category': 'ES - Accommodation LDN',
-        'session-rar-subcategory': 'Accommodation (Custody Transition)',
-        'type-of-session': 'Home visit',
-        'repeating': 'No, it’s a one-off session',
-        'confirmed': true,
-      }
+      123: cases
+        .find(entry => entry.CRN === 'J678910')
+        .contactHistory
+        .find(entry => entry.sessionId === 123)
     }
   }
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   'team-codes': ['C17ETE'],
   cases: cases,
-  'contact-history': cases.reduce(contactHistoryDefaults, {}),
+  'communication': cases.reduce(contactHistoryDefaults, {}),
   'confirm-attendance': cases.reduce(confirmAttendanceDefaults, {}),
   'arrange-a-session': {
     'J678910': {
@@ -40,7 +40,7 @@ module.exports = {
         'session-rar-subcategory': 'Accommodation (Custody Transition)',
         'type-of-session': 'Home visit',
         'repeating': 'No, it’s a one-off session',
-        'confirmed': true
+        'confirmed': true,
       }
     }
   }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -3,10 +3,17 @@ const cases = require('./cases')
 const helpers = require(path.join(__dirname, '../../lib/helpers.js'))
 
 const confirmAttendanceDefaults = (map, su) => {
-  if (su.previousAppointment) {
+  if (su.previousAppointment && su.previousAppointment.sessionId) {
     map[su.CRN] = {
       [su.previousAppointment.sessionId]: su.previousAppointment
     }
+  }
+  return map
+}
+
+const contactHistoryDefaults = (map, su) => {
+  if (su.contactHistory) {
+    map[su.CRN] = su.contactHistory.reduce((o, contact) => ({ ...o, [contact.sessionId]: contact}), {})
   }
   return map
 }
@@ -19,6 +26,7 @@ module.exports = {
   },
   'team-codes': ['C17ETE'],
   cases: cases,
+  'contact-history': cases.reduce(contactHistoryDefaults, {}),
   'confirm-attendance': cases.reduce(confirmAttendanceDefaults, {}),
   'arrange-a-session': {
     'J678910': {

--- a/app/routes/arrange-a-session.js
+++ b/app/routes/arrange-a-session.js
@@ -18,7 +18,7 @@ module.exports = router => {
   router.get('/arrange-a-session/:CRN/:sessionId/confirmation', (req, res, next) => {
     setDataValue(req.session.data,
       [
-        'arrange-a-session',
+        'communication',
         req.params.CRN,
         req.params.sessionId,
         'confirmed'
@@ -29,7 +29,7 @@ module.exports = router => {
   router.get('/arrange-a-session/:CRN/:sessionId/cancel-confirmation', (req, res, next) => {
     setDataValue(req.session.data,
       [
-        'arrange-a-session',
+        'communication',
         req.params.CRN,
         req.params.sessionId,
         'cancelled'

--- a/app/utils/arrange-a-session-wizard-paths.js
+++ b/app/utils/arrange-a-session-wizard-paths.js
@@ -33,19 +33,19 @@ function arrangeSessionWizardForks (req) {
   var forks = [
     {
       currentPath: `/arrange-a-session/${CRN}/${sessionId}`,
-      storedData: ['arrange-a-session', CRN, sessionId, 'type-of-session'],
+      storedData: ['communication', CRN, sessionId, 'type-of-session'],
       excludedValues: ['Office visit', 'Other'],
       forkPath: `/arrange-a-session/${CRN}/${sessionId}/when`
     },
     {
       currentPath: `/arrange-a-session/${CRN}/${sessionId}/rar`,
-      storedData: ['arrange-a-session', CRN, sessionId, 'session-counts-towards-rar'],
+      storedData: ['communication', CRN, sessionId, 'session-counts-towards-rar'],
       values: ['No'],
       forkPath: `/arrange-a-session/${CRN}/${sessionId}/check`
     },
     {
       currentPath: `/arrange-a-session/${CRN}/${sessionId}/rearrange-or-cancel`,
-      storedData: ['arrange-a-session', CRN, sessionId, 'rearrange-or-cancel'],
+      storedData: ['communication', CRN, sessionId, 'rearrange-or-cancel'],
       values: ['Rearrange session'],
       forkPath: `/arrange-a-session/${CRN}/${sessionId}`
     }

--- a/app/utils/confirm-attendance-wizard-paths.js
+++ b/app/utils/confirm-attendance-wizard-paths.js
@@ -8,7 +8,7 @@ function confirmAttendanceWizardPaths (req) {
   const sessionId = req.params.sessionId
 
   var paths = [
-    `/cases/${CRN}/timeline`,
+    `/cases/${CRN}/communication`,
     `/confirm-attendance/${CRN}/${sessionId}`,
     `/confirm-attendance/${CRN}/${sessionId}/compliance`,
     `/confirm-attendance/${CRN}/${sessionId}/non-compliance-reason`,

--- a/app/views/arrange-a-session/_session-details.html
+++ b/app/views/arrange-a-session/_session-details.html
@@ -2,15 +2,15 @@
 
 {% set session = arrangedSession({
   providerCode: data['provider-code'],
-  typeOfSession: data['arrange-a-session'][CRN][sessionId]['type-of-session'],
-  contactType: data['arrange-a-session'][CRN][sessionId]['other-type-of-session'],
-  date: data['arrange-a-session'][CRN][sessionId]['session-date'],
-  startTime: data['arrange-a-session'][CRN][sessionId]['session-start-time'],
-  endTime: data['arrange-a-session'][CRN][sessionId]['session-end-time'],
-  countsTowardsRAR: data['arrange-a-session'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes',
-  rarCategory: data['arrange-a-session'][CRN][sessionId]['session-rar-category'],
-  rarSubCategory: data['arrange-a-session'][CRN][sessionId]['session-rar-subcategory'],
-  locationCode: data['arrange-a-session'][CRN][sessionId]['session-location-code']
+  typeOfSession: data['communication'][CRN][sessionId]['type-of-session'],
+  contactType: data['communication'][CRN][sessionId]['other-type-of-session'],
+  date: data['communication'][CRN][sessionId]['session-date'],
+  startTime: data['communication'][CRN][sessionId]['session-start-time'],
+  endTime: data['communication'][CRN][sessionId]['session-end-time'],
+  countsTowardsRAR: data['communication'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes',
+  rarCategory: data['communication'][CRN][sessionId]['session-rar-category'],
+  rarSubCategory: data['communication'][CRN][sessionId]['session-rar-subcategory'],
+  locationCode: data['communication'][CRN][sessionId]['session-location-code']
 }) %}
 
 {{ govukSummaryList({
@@ -19,7 +19,7 @@
     {
       key: { text: "Reason for cancelling" if cancelling else "Reason for rearranging" },
       value: {
-        text: data['arrange-a-session'][CRN][sessionId]['rearrange-or-cancel-reason']
+        text: data['communication'][CRN][sessionId]['rearrange-or-cancel-reason']
       },
       actions: {
         items: [
@@ -30,7 +30,7 @@
           }
         ]
       }
-    } if data['arrange-a-session'][CRN][sessionId]['rearrange-or-cancel-reason'],
+    } if data['communication'][CRN][sessionId]['rearrange-or-cancel-reason'],
     {
       key: { text: "Type of appointment" },
       value: { text: session.summary.typeOfSession },
@@ -111,7 +111,7 @@
     } if not session.summary.countsTowardsRAR,
     {
       key: { text: "Calendar note" },
-      value: { text: data['arrange-a-session'][CRN][sessionId]['session-notes'] or 'None' },
+      value: { text: data['communication'][CRN][sessionId]['session-notes'] or 'None' },
       actions: {
         items: [
           {

--- a/app/views/arrange-a-session/cancel-confirmation.html
+++ b/app/views/arrange-a-session/cancel-confirmation.html
@@ -5,15 +5,15 @@
 {% block page %}
   {% set session = arrangedSession({
     providerCode: data['provider-code'],
-    typeOfSession: data['arrange-a-session'][CRN][sessionId]['type-of-session'],
-    contactType: data['arrange-a-session'][CRN][sessionId]['other-type-of-session'],
-    date: data['arrange-a-session'][CRN][sessionId]['session-date'],
-    startTime: data['arrange-a-session'][CRN][sessionId]['session-start-time'],
-    endTime: data['arrange-a-session'][CRN][sessionId]['session-end-time'],
-    countsTowardsRAR: data['arrange-a-session'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes',
-    rarCategory: data['arrange-a-session'][CRN][sessionId]['session-rar-category'],
-    rarSubCategory: data['arrange-a-session'][CRN][sessionId]['session-rar-subcategory'],
-    locationCode: data['arrange-a-session'][CRN][sessionId]['session-location-code']
+    typeOfSession: data['communication'][CRN][sessionId]['type-of-session'],
+    contactType: data['communication'][CRN][sessionId]['other-type-of-session'],
+    date: data['communication'][CRN][sessionId]['session-date'],
+    startTime: data['communication'][CRN][sessionId]['session-start-time'],
+    endTime: data['communication'][CRN][sessionId]['session-end-time'],
+    countsTowardsRAR: data['communication'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes',
+    rarCategory: data['communication'][CRN][sessionId]['session-rar-category'],
+    rarSubCategory: data['communication'][CRN][sessionId]['session-rar-subcategory'],
+    locationCode: data['communication'][CRN][sessionId]['session-location-code']
   }) %}
 
   {% set panelHtml %}

--- a/app/views/arrange-a-session/check.html
+++ b/app/views/arrange-a-session/check.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set rearranging = data['arrange-a-session'][CRN][sessionId]['rearrange-or-cancel'] %}
+{% set rearranging = data['communication'][CRN][sessionId]['rearrange-or-cancel'] %}
 {% set buttonText = 'Rearrange appointment' if rearranging else 'Arrange appointment' %}
 {% set title = 'Check your answers and confirm appointment' %}
 

--- a/app/views/arrange-a-session/confirmation.html
+++ b/app/views/arrange-a-session/confirmation.html
@@ -1,20 +1,20 @@
 {% extends "_wizard-page.html" %}
-{% set rearranging = data['arrange-a-session'][CRN][sessionId]['rearrange-or-cancel'] %}
+{% set rearranging = data['communication'][CRN][sessionId]['rearrange-or-cancel'] %}
 {% set buttonText = 'Finish' %}
 {% set title = "Appointment rearranged" if rearranging else "Appointment arranged" %}
 
 {% block page %}
   {% set session = arrangedSession({
     providerCode: data['provider-code'],
-    typeOfSession: data['arrange-a-session'][CRN][sessionId]['type-of-session'],
-    contactType: data['arrange-a-session'][CRN][sessionId]['other-type-of-session'],
-    date: data['arrange-a-session'][CRN][sessionId]['session-date'],
-    startTime: data['arrange-a-session'][CRN][sessionId]['session-start-time'],
-    endTime: data['arrange-a-session'][CRN][sessionId]['session-end-time'],
-    countsTowardsRAR: data['arrange-a-session'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes',
-    rarCategory: data['arrange-a-session'][CRN][sessionId]['session-rar-category'],
-    rarSubCategory: data['arrange-a-session'][CRN][sessionId]['session-rar-subcategory'],
-    locationCode: data['arrange-a-session'][CRN][sessionId]['session-location-code']
+    typeOfSession: data['communication'][CRN][sessionId]['type-of-session'],
+    contactType: data['communication'][CRN][sessionId]['other-type-of-session'],
+    date: data['communication'][CRN][sessionId]['session-date'],
+    startTime: data['communication'][CRN][sessionId]['session-start-time'],
+    endTime: data['communication'][CRN][sessionId]['session-end-time'],
+    countsTowardsRAR: data['communication'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes',
+    rarCategory: data['communication'][CRN][sessionId]['session-rar-category'],
+    rarSubCategory: data['communication'][CRN][sessionId]['session-rar-subcategory'],
+    locationCode: data['communication'][CRN][sessionId]['session-location-code']
   }) %}
 
   {% set panelHtml %}

--- a/app/views/arrange-a-session/index.html
+++ b/app/views/arrange-a-session/index.html
@@ -18,7 +18,7 @@
        },
        id: 'other-type-of-session',
        items: contactTypeSelectItems
-    } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'other-type-of-session'])) }}
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'other-type-of-session'])) }}
   {% endset %}
 
   {{ govukRadios({
@@ -47,7 +47,10 @@
          conditional: { html: otherHtml }
       }
     ]
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'type-of-session'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'type-of-session'])) }}
 
-  <input type="hidden" id="type" name="[arrange-a-session][{{ CRN }}][{{ sessionId }}][type]" value="Appointment">
+  <input type="hidden" id="type" name="[communication][{{ CRN }}][{{ sessionId }}][type]" value="Appointment">
+  <input type="hidden" id="lastUpdatedBy" name="[communication][{{ CRN }}][{{ sessionId }}][lastUpdatedBy]" value="Mark Berridge">
+  <input type="hidden" id="timestamp" name="[communication][{{ CRN }}][{{ sessionId }}][timestamp]" value="{{ currentTimeString() }}">
+  <input type="hidden" id="sessionId" name="[communication][{{ CRN }}][{{ sessionId }}][sessionId]" value="{{ sessionId }}">
 {% endblock %}

--- a/app/views/arrange-a-session/index.html
+++ b/app/views/arrange-a-session/index.html
@@ -48,4 +48,6 @@
       }
     ]
   } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'type-of-session'])) }}
+
+  <input type="hidden" id="type" name="[arrange-a-session][{{ CRN }}][{{ sessionId }}][type]" value="Appointment">
 {% endblock %}

--- a/app/views/arrange-a-session/rar-categories.html
+++ b/app/views/arrange-a-session/rar-categories.html
@@ -5,8 +5,8 @@
   {% set rarRadioItems = [] %}
   {% for rarCategory in possibleRARCategories(
     data['provider-code'],
-    data['arrange-a-session'][CRN][sessionId]['type-of-session'],
-    data['arrange-a-session'][CRN][sessionId]['other-type-of-session']) %}
+    data['communication'][CRN][sessionId]['type-of-session'],
+    data['communication'][CRN][sessionId]['other-type-of-session']) %}
     {% set rarSubCategoryRadioItems = [] %}
     {% for rarSubCategoryCode, subCategory in rarCategory.nsiSubTypes %}
       {% set rarSubCategoryRadioItems = (rarSubCategoryRadioItems.push({
@@ -18,7 +18,7 @@
     {% set rarSubCategoryHtml %}
       {{ govukRadios({
         items: rarSubCategoryRadioItems
-      } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'session-rar-subcategory'])) }}
+      } | decorateFormAttributes(['communication', CRN, sessionId, 'session-rar-subcategory'])) }}
     {% endset %}
 
     {% set rarRadioItems = (rarRadioItems.push({
@@ -39,5 +39,5 @@
         }
       },
       items: rarRadioItems
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'session-rar-category'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'session-rar-category'])) }}
 {% endblock %}

--- a/app/views/arrange-a-session/rar.html
+++ b/app/views/arrange-a-session/rar.html
@@ -21,12 +21,12 @@
           text: 'No'
         }
       ]
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'session-counts-towards-rar'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'session-counts-towards-rar'])) }}
 
   {{ govukTextarea({
     label: {
       text: 'Add a calendar note (optional)',
       classes: 'govuk-label--l'
     }
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'session-notes'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'session-notes'])) }}
 {% endblock %}

--- a/app/views/arrange-a-session/rearrange-or-cancel.html
+++ b/app/views/arrange-a-session/rearrange-or-cancel.html
@@ -18,12 +18,12 @@
         text: 'Cancel appointment'
       }
     ]
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'rearrange-or-cancel'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'rearrange-or-cancel'])) }}
 
   {{ govukTextarea({
       label: {
         text: 'Why do you need to make this change?',
         classes: 'govuk-label--m'
       }
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'rearrange-or-cancel-reason'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'rearrange-or-cancel-reason'])) }}
 {% endblock %}

--- a/app/views/arrange-a-session/when.html
+++ b/app/views/arrange-a-session/when.html
@@ -37,9 +37,9 @@
             <input
               class="govuk-input govuk-date-input__input"
               type="date"
-              id="[arrange-a-session][{{CRN}}][{{sessionId}}][session-date]"
-              name="[arrange-a-session][{{CRN}}][{{sessionId}}][session-date]"
-              value="{{ data['arrange-a-session'][CRN][sessionId]['session-date'] }}"
+              id="[communication][{{CRN}}][{{sessionId}}][session-date]"
+              name="[communication][{{CRN}}][{{sessionId}}][session-date]"
+              value="{{ data['communication'][CRN][sessionId]['session-date'] }}"
               placeholder="DD/MM/YYYY">
           </div>
         </div>
@@ -56,8 +56,8 @@
         class="govuk-input govuk-input--width-5"
         type="text"
         id="session-start-time"
-        name="[arrange-a-session][{{CRN}}][{{sessionId}}][session-start-time]"
-        value="{{ data['arrange-a-session'][CRN][sessionId]['session-start-time'] }}">
+        name="[communication][{{CRN}}][{{sessionId}}][session-start-time]"
+        value="{{ data['communication'][CRN][sessionId]['session-start-time'] }}">
     </div>
     <span class="govuk-body" style="margin:0 0.75rem 0 0.75rem;">to</span>
     <div class="autocomplete">
@@ -65,8 +65,8 @@
         class="govuk-input govuk-input--width-5"
         type="text"
         id="session-end-time"
-        name="[arrange-a-session][{{CRN}}][{{sessionId}}][session-end-time]"
-        value="{{ data['arrange-a-session'][CRN][sessionId]['session-end-time'] }}">
+        name="[communication][{{CRN}}][{{sessionId}}][session-end-time]"
+        value="{{ data['communication'][CRN][sessionId]['session-end-time'] }}">
     </div>
   </div>
 
@@ -92,7 +92,7 @@
           text: "Monthly"
         }
       ]
-    } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'repeating-frequency'])) }}
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'repeating-frequency'])) }}
 
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset" role="group">
@@ -105,9 +105,9 @@
               <input
                 class="govuk-input govuk-date-input__input"
                 type="date"
-                id="[arrange-a-session][{{CRN}}][{{sessionId}}][repeat-end-date]"
-                name="[arrange-a-session][{{CRN}}][{{sessionId}}][repeat-end-date]"
-                value="{{ data['arrange-a-session'][CRN][sessionId]['repeat-end-date'] }}"
+                id="[communication][{{CRN}}][{{sessionId}}][repeat-end-date]"
+                name="[communication][{{CRN}}][{{sessionId}}][repeat-end-date]"
+                value="{{ data['communication'][CRN][sessionId]['repeat-end-date'] }}"
                 placeholder="DD/MM/YYYY">
             </div>
           </div>
@@ -134,5 +134,5 @@
         text: "No, it’s a one-off appointment"
       }
     ]
-  } | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'repeating'])) }}
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'repeating'])) }}
 {% endblock %}

--- a/app/views/arrange-a-session/where.html
+++ b/app/views/arrange-a-session/where.html
@@ -19,5 +19,5 @@
       }
     },
     items: locationItems
-  }  | decorateFormAttributes(['arrange-a-session', CRN, sessionId, 'session-location-code'])) }}
+  }  | decorateFormAttributes(['communication', CRN, sessionId, 'session-location-code'])) }}
 {% endblock %}

--- a/app/views/case/_appointment-timeline-entry.html
+++ b/app/views/case/_appointment-timeline-entry.html
@@ -45,14 +45,18 @@
   ]
 }) }}
 
-{% if entry['session-notes'] or not entry['did-service-user-comply'] %}
+{% set hasAttendanceAlreadyBeenConfirmed = not not entry['did-service-user-comply'] %}
+{% set hasAppointmentTimePassed = isInThePast({date: entry['session-date'], time: entry['session-end-time']}) %}
+{% set shouldPromptToConfirmAttendance = (not hasAttendanceAlreadyBeenConfirmed) and hasAppointmentTimePassed %}
+
+{% if entry['session-notes'] or shouldPromptToConfirmAttendance %}
   <div class="note-panel">
-    {% if not entry['did-service-user-comply'] %}
+    {% if shouldPromptToConfirmAttendance  %}
       {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/' + entry.sessionId + '">Confirm attendance</a>') }}
     {% endif %}
 
     {% set truncatedContents = entry['session-notes'] | truncate(300) %}
-    {% set isTruncated = (truncatedContents !== entry['session-notes']) %}
+    {% set isTruncated = entry['session-notes'] and (truncatedContents !== entry['session-notes']) %}
     <p class="govuk-body {{ 'govuk-!-margin-bottom-0' if not isTruncated }}">{{ truncatedContents | nl2br | safe }}</p>
     {% if isTruncated %}
       <a href="#">View full details</a>

--- a/app/views/case/communication.html
+++ b/app/views/case/communication.html
@@ -18,7 +18,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     {% set hr = joiner('<hr>') %}
-    {% for entry in case.contactHistory %}
+    {% for entry in communicationEntries(CRN, data) %}
 
       {{ hr() | safe }}
 

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -106,13 +106,14 @@
     <h2 class="govuk-heading-m">
       Next appointment
     </h2>
+    {% set nextApp = nextAppointment(CRN, data) %}
     <div class="app-card app-card--blue govuk-!-margin-bottom-3">
-      {{ data['arrange-a-session'][CRN][123]['type-of-session'] }}<br>
+      {{ nextApp['type-of-session'] }}<br>
       <strong>
-        {{ data['arrange-a-session'][CRN][123]['session-date'] | dateWithDayAndWithoutYear }} from<br>
-        {{ data['arrange-a-session'][CRN][123]['session-start-time'] }} to {{ data['arrange-a-session'][CRN][123]['session-end-time'] }}
+        {{ nextApp['session-date'] | dateWithDayAndWithoutYear }} from<br>
+        {{ nextApp['session-start-time'] }} to {{ nextApp['session-end-time'] }}
       </strong>
-      <a href="/arrange-a-session/{{ CRN }}/123/rearrange-or-cancel" class="govuk-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+      <a href="/arrange-a-session/{{ CRN }}/{{ nextApp.sessionId }}/rearrange-or-cancel" class="govuk-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
         data-module="govuk-button">
         Rearrange or cancel appointment
       </a>

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -112,8 +112,8 @@
         {{ data['arrange-a-session'][CRN][123]['session-date'] | dateWithDayAndWithoutYear }} from<br>
         {{ data['arrange-a-session'][CRN][123]['session-start-time'] }} to {{ data['arrange-a-session'][CRN][123]['session-end-time'] }}
       </strong>
-      <a href="/arrange-a-session/{{ CRN }}/123/rearrange-or-cancel" class="govuk-button govuk-button--secondary govuk-!-margin-top-4"
-        data-module="govuk-button" style="margin-bottom: 0;">
+      <a href="/arrange-a-session/{{ CRN }}/123/rearrange-or-cancel" class="govuk-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
+        data-module="govuk-button">
         Rearrange or cancel appointment
       </a>
     </div>

--- a/app/views/cases/_case-list-data.html
+++ b/app/views/cases/_case-list-data.html
@@ -35,9 +35,10 @@
           <td class="govuk-table__cell">
             <span class="govuk-tag govuk-tag--{{ case.riskOfSeriousHarmLevel.class }}">{{ case.riskOfSeriousHarmLevel.text }}</span>
           </td>
+          {% set nextApp = nextAppointment(case.CRN, data) %}
           <td class="govuk-table__cell">
-            {% if data['arrange-a-session'][case.CRN][123] %}
-              {{ data['arrange-a-session'][case.CRN][123]['session-date'] | dateWithDayAndWithoutYear }} at {{ data['arrange-a-session'][case.CRN][123]['session-start-time'] }}
+            {% if nextApp %}
+              {{ nextApp['session-date'] | dateWithDayAndWithoutYear }} at {{ nextApp['session-start-time'] }}
             {% else %}
               {{ govukTag({text: 'Unscheduled', classes: 'govuk-tag--grey'}) }}
             {% endif %}

--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -8,7 +8,7 @@
         text: "Why was this absence acceptable?"
       },
       classes: 'govuk-!-width-two-thirds'
-    } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'why-absence-acceptable'])) }}
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'why-absence-acceptable'])) }}
   {% endset %}
 
   {{ govukRadios({
@@ -33,6 +33,6 @@
            value: 'No'
          }
        ]
-       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
+       } | decorateFormAttributes(['communication', CRN, sessionId, 'was-absence-acceptable']))
   }}
 {% endblock %}

--- a/app/views/confirm-attendance/add-notes.html
+++ b/app/views/confirm-attendance/add-notes.html
@@ -24,6 +24,6 @@
            value: 'No'
          }
        ]
-       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'add-notes']))
+       } | decorateFormAttributes(['communication', CRN, sessionId, 'add-notes']))
   }}
 {% endblock %}

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -5,14 +5,14 @@
 {% block form %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
 
-  {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['confirm-attendance'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['confirm-attendance'][CRN][sessionId]['did-service-user-comply']  %}
+  {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['communication'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['communication'][CRN][sessionId]['did-service-user-comply']  %}
 
   {{ govukSummaryList({
     classes: 'govuk-!-margin-bottom-9',
     rows: [
       {
         key: { text: "RAR activity" },
-        value: { text: data['confirm-attendance'][CRN][sessionId]['session-rar-category'] if data['confirm-attendance'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes' else 'None'  },
+        value: { text: data['communication'][CRN][sessionId]['session-rar-category'] if data['communication'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes' else 'None'  },
         actions: {
           items: [
             {
@@ -38,7 +38,7 @@
       },
       {
         key: { text: "Appointment notes" },
-        value: { text: data['confirm-attendance'][CRN][sessionId]['notes'] if data['confirm-attendance'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
+        value: { text: data['communication'][CRN][sessionId]['notes'] if data['communication'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
         actions: {
           items: [
             {
@@ -55,7 +55,7 @@
   <p class="govuk-body">You’re confirming attendance for:</p>
 
   <div class="govuk-inset-text">
-    <strong>{{ data['confirm-attendance'][CRN][sessionId]['type-of-session'] }}</strong><br>
-    {{ data['confirm-attendance'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId]['session-start-time'] }} to {{ data['confirm-attendance'][CRN][sessionId]['session-end-time'] }}
+    <strong>{{ data['communication'][CRN][sessionId]['type-of-session'] }}</strong><br>
+    {{ data['communication'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['communication'][CRN][sessionId]['session-start-time'] }} to {{ data['communication'][CRN][sessionId]['session-end-time'] }}
   </div>
 {% endblock %}

--- a/app/views/confirm-attendance/check.html
+++ b/app/views/confirm-attendance/check.html
@@ -38,7 +38,7 @@
       },
       {
         key: { text: "Appointment notes" },
-        value: { text: data['communication'][CRN][sessionId]['notes'] if data['communication'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
+        value: { text: data['communication'][CRN][sessionId]['session-notes'] if data['communication'][CRN][sessionId]['add-notes'] == 'Yes' else 'None' },
         actions: {
           items: [
             {

--- a/app/views/confirm-attendance/compliance.html
+++ b/app/views/confirm-attendance/compliance.html
@@ -25,6 +25,6 @@
            value: 'Absent'
          }
        ]
-       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'did-service-user-comply']))
+       } | decorateFormAttributes(['communication', CRN, sessionId, 'did-service-user-comply']))
   }}
 {% endblock %}

--- a/app/views/confirm-attendance/confirmation.html
+++ b/app/views/confirm-attendance/confirmation.html
@@ -5,8 +5,8 @@
 {% block page %}
 
   {% set panelHtml %}
-    <strong>{{ data['confirm-attendance'][CRN][sessionId]['type-of-session'] }}</strong><br>
-    {{ data['confirm-attendance'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId]['session-start-time'] }} to {{ data['confirm-attendance'][CRN][sessionId]['session-end-time'] }}
+    <strong>{{ data['communication'][CRN][sessionId]['type-of-session'] }}</strong><br>
+    {{ data['communication'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['communication'][CRN][sessionId]['session-start-time'] }} to {{ data['communication'][CRN][sessionId]['session-end-time'] }}
   {% endset %}
 
   {{ govukPanel({

--- a/app/views/confirm-attendance/non-compliance-reason.html
+++ b/app/views/confirm-attendance/non-compliance-reason.html
@@ -9,7 +9,7 @@
         text: "Give details"
       },
       classes: 'govuk-!-width-two-thirds'
-    } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'non-compliance-reason'])) }}
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'non-compliance-reason'])) }}
   {% endset %}
 
   {{ govukRadios({
@@ -34,6 +34,6 @@
            }
          }
        ]
-       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'was-absence-acceptable']))
+       } | decorateFormAttributes(['communication', CRN, sessionId, 'was-absence-acceptable']))
   }}
 {% endblock %}

--- a/app/views/confirm-attendance/notes.html
+++ b/app/views/confirm-attendance/notes.html
@@ -55,7 +55,7 @@
       name: "notes",
       id: "notes",
       rows: 10
-    } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'notes'])) }}
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'notes'])) }}
 
   </div>
 

--- a/app/views/confirm-attendance/notes.html
+++ b/app/views/confirm-attendance/notes.html
@@ -55,7 +55,7 @@
       name: "notes",
       id: "notes",
       rows: 10
-    } | decorateFormAttributes(['communication', CRN, sessionId, 'notes'])) }}
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'session-notes'])) }}
 
   </div>
 

--- a/app/views/confirm-attendance/rar-categories.html
+++ b/app/views/confirm-attendance/rar-categories.html
@@ -30,7 +30,7 @@
              }
            },
            items: rarRadioItems
-         } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'session-rar-category']) )
+         } | decorateFormAttributes(['communication', CRN, sessionId, 'session-rar-category']) )
       }}
   {% endset %}
 
@@ -58,5 +58,5 @@
            value: 'No'
          }
        ]
-       } | decorateFormAttributes(['confirm-attendance', CRN, sessionId, 'session-counts-towards-rar']) ) }}
+       } | decorateFormAttributes(['communication', CRN, sessionId, 'session-counts-towards-rar']) ) }}
 {% endblock %}

--- a/app/views/confirm-attendance/start.html
+++ b/app/views/confirm-attendance/start.html
@@ -7,7 +7,7 @@
   <p class="govuk-body">You’re confirming attendance for:</p>
 
   <div class="govuk-inset-text">
-    <strong>{{ data['confirm-attendance'][CRN][sessionId]['type-of-session'] }}</strong><br>
-    {{ data['confirm-attendance'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['confirm-attendance'][CRN][sessionId]['session-start-time'] }} to {{ data['confirm-attendance'][CRN][sessionId]['session-end-time'] }}
+    <strong>{{ data['communication'][CRN][sessionId]['type-of-session'] }}</strong><br>
+    {{ data['communication'][CRN][sessionId]['session-date'] | dateWithDayAndWithoutYear }} from {{ data['communication'][CRN][sessionId]['session-start-time'] }} to {{ data['communication'][CRN][sessionId]['session-end-time'] }}
   </div>
 {% endblock %}

--- a/app/views/includes/ndelius-record-details.html
+++ b/app/views/includes/ndelius-record-details.html
@@ -1,14 +1,14 @@
 {% set session = arrangedSession({
   providerCode: data['provider-code'],
-  typeOfSession: data['arrange-a-session'][CRN]['type-of-session'],
-  contactType: data['arrange-a-session'][CRN]['other-type-of-session'],
-  date: data['arrange-a-session'][CRN]['session-date'],
-  startTime: data['arrange-a-session'][CRN]['session-start-time'],
-  endTime: data['arrange-a-session'][CRN]['session-end-time'],
-  countsTowardsRAR: data['arrange-a-session'][CRN]['session-counts-towards-rar'] == 'Yes',
-  rarCategory: data['arrange-a-session'][CRN]['session-rar-category'],
-  rarSubCategory: data['arrange-a-session'][CRN]['session-rar-subcategory'],
-  locationCode: data['arrange-a-session'][CRN]['session-location-code']
+  typeOfSession: data['communication'][CRN]['type-of-session'],
+  contactType: data['communication'][CRN]['other-type-of-session'],
+  date: data['communication'][CRN]['session-date'],
+  startTime: data['communication'][CRN]['session-start-time'],
+  endTime: data['communication'][CRN]['session-end-time'],
+  countsTowardsRAR: data['communication'][CRN]['session-counts-towards-rar'] == 'Yes',
+  rarCategory: data['communication'][CRN]['session-rar-category'],
+  rarSubCategory: data['communication'][CRN]['session-rar-subcategory'],
+  locationCode: data['communication'][CRN]['session-location-code']
 }) %}
 
 {% set ndeliusDataHTML %}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,6 +48,10 @@ exports.yearsSince = (time) => {
   return i.toDuration(['years', 'months']).years
 }
 
+exports.currentTimeString = () => {
+  return DateTime.now().toISO()
+}
+
 // example params = { date: '2021-04-16', time: '4pm' }
 exports.isInThePast = (params) => {
   // normalise 4pm => 4:00pm
@@ -103,6 +107,8 @@ exports.addHelpers = function (env) {
   env.addGlobal('possibleLocations', exports.possibleLocations)
 
   env.addGlobal('yearsSince', exports.yearsSince)
+
+  env.addGlobal('currentTimeString', exports.currentTimeString)
 
   env.addGlobal('communicationEntries', exports.communicationEntries)
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,9 +48,20 @@ exports.yearsSince = (time) => {
   return i.toDuration(['years', 'months']).years
 }
 
+// example params = { date: '2021-04-16', time: '4pm' }
+exports.isInThePast = (params) => {
+  // normalise 4pm => 4:00pm
+  if (!params.time.includes(':')) {
+    params.time = params.time.replace(/(\d+)(am|pm)/, '$1:00$2')
+  }
+
+  const time = DateTime.fromString(`${params.date} ${params.time}`, 'yyyy-MM-dd h:mma', {zone: 'utc'})
+  return DateTime.now() > time
+}
+
 exports.communicationEntries = (CRN, data, params = {}) => {
   return Object
-    .values(data['contact-history'][CRN])
+    .values(data['communication'][CRN])
     .sort((a, b) => a.timestamp < b.timestamp ? 1 : -1)
     .slice(0, params.first || Number.MAX_SAFE_INTEGER)
 }
@@ -69,4 +80,6 @@ exports.addHelpers = function (env) {
   env.addGlobal('yearsSince', exports.yearsSince)
 
   env.addGlobal('communicationEntries', exports.communicationEntries)
+
+  env.addGlobal('isInThePast', exports.isInThePast)
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,11 +59,36 @@ exports.isInThePast = (params) => {
   return DateTime.now() > time
 }
 
+exports.endDateTime = (appointment) => {
+  var timeString
+  // normalise 4pm => 4:00pm
+  if (!appointment['session-end-time'].includes(':')) {
+    timeString = appointment['session-end-time'].replace(/(\d+)(am|pm)/, '$1:00$2')
+  } else {
+    timeString = appointment['session-end-time']
+  }
+
+  return DateTime.fromString(`${appointment['session-date']} ${timeString}`, 'yyyy-MM-dd h:mma', {zone: 'utc'})
+}
+
 exports.communicationEntries = (CRN, data, params = {}) => {
   return Object
     .values(data['communication'][CRN])
     .sort((a, b) => a.timestamp < b.timestamp ? 1 : -1)
     .slice(0, params.first || Number.MAX_SAFE_INTEGER)
+}
+
+exports.futureAppointments = (CRN, data) => {
+  return Object
+    .values(data['communication'][CRN])
+    .filter(entry => entry.type === 'Appointment' )
+    .filter(entry => !exports.isInThePast({date: entry['session-date'], time: entry['session-end-time']}) )
+}
+
+exports.nextAppointment = (CRN, data) => {
+  return exports.futureAppointments(CRN, data)
+    .sort((a, b) => exports.endDateTime(a) < exports.endDateTime(b) ? -1 : 1)
+    .shift()
 }
 
 exports.addHelpers = function (env) {
@@ -82,4 +107,6 @@ exports.addHelpers = function (env) {
   env.addGlobal('communicationEntries', exports.communicationEntries)
 
   env.addGlobal('isInThePast', exports.isInThePast)
+
+  env.addGlobal('nextAppointment', exports.nextAppointment)
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,6 +48,13 @@ exports.yearsSince = (time) => {
   return i.toDuration(['years', 'months']).years
 }
 
+exports.communicationEntries = (CRN, data, params = {}) => {
+  return Object
+    .values(data['contact-history'][CRN])
+    .sort((a, b) => a.timestamp < b.timestamp ? 1 : -1)
+    .slice(0, params.first || Number.MAX_SAFE_INTEGER)
+}
+
 exports.addHelpers = function (env) {
   env.addGlobal('progressPercentage', exports.progressPercentage)
 
@@ -60,4 +67,6 @@ exports.addHelpers = function (env) {
   env.addGlobal('possibleLocations', exports.possibleLocations)
 
   env.addGlobal('yearsSince', exports.yearsSince)
+
+  env.addGlobal('communicationEntries', exports.communicationEntries)
 }


### PR DESCRIPTION
* Show future appointments in the 'communication' view
* The next appointment is calculated dynamically
* Arranging an appointment makes it appear in the communication list and in the next appointment block if it's the next one