### PR TITLE
Switch styles to use govuk-frontend mixins

### DIFF
--- a/app/assets/sass/components/_app-card-meta-list.scss
+++ b/app/assets/sass/components/_app-card-meta-list.scss
@@ -1,42 +1,41 @@
 .app-card__meta-list {
-    font-family: "GDS Transport", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 1.25;
-    width: 100%;
-    margin: 0 0 20px;
-  }
-  
-  .app-card__meta-list-item {
-    margin-bottom: 10px;
-  }
-  
-  .app-card__meta-list-key, .app-card__meta-list-value {
-    display: block;
-  }
-  
-  .app-card__meta-list-key {
-    font-weight: 700;
-  }
-  
-  .app-card__meta-list-value {
-    margin: 0;
-  }
-  
-  @media (min-width: 48.0625em) {
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  width: 100%;
+  margin: 0 0 20px;
+}
+
+.app-card__meta-list-item {
+  margin-bottom: 10px;
+}
+
+.app-card__meta-list-key, .app-card__meta-list-value {
+  display: block;
+}
+
+.app-card__meta-list-key {
+  font-weight: 700;
+}
+
+.app-card__meta-list-value {
+  margin: 0;
+}
+
+@media (min-width: 48.0625em) {
   .app-card__meta-list {
-      display: grid;
-      grid-template-columns: repeat(5,1fr);
-      grid-gap: 15px;
-    } 
+    display: grid;
+    grid-template-columns: repeat(5,1fr);
+    grid-gap: 15px;
   }
-  
-  @media (min-width: 40.0625em) {
+}
+
+@media (min-width: 40.0625em) {
   .app-card__meta-list {
-      font-size: 19px;
-      line-height: 1.5;
-  
-    }
+    font-size: 19px;
+    line-height: 1.5;
   }
+}

--- a/app/assets/sass/components/_app-card-meta-list.scss
+++ b/app/assets/sass/components/_app-card-meta-list.scss
@@ -1,16 +1,24 @@
 .app-card__meta-list {
-  font-family: "GDS Transport", Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 1.25;
-  width: 100%;
-  margin: 0 0 20px;
+  @include govuk-font($size: 16);
+  margin-bottom: govuk-spacing(4);
+}
+
+@media (min-width: 48.0625em) {
+  .app-card__meta-list {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    grid-gap: govuk-spacing(3);
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .app-card__meta-list {
+    @include govuk-font($size: 19);
+  }
 }
 
 .app-card__meta-list-item {
-  margin-bottom: 10px;
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-card__meta-list-key, .app-card__meta-list-value {
@@ -23,19 +31,4 @@
 
 .app-card__meta-list-value {
   margin: 0;
-}
-
-@media (min-width: 48.0625em) {
-  .app-card__meta-list {
-    display: grid;
-    grid-template-columns: repeat(5,1fr);
-    grid-gap: 15px;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  .app-card__meta-list {
-    font-size: 19px;
-    line-height: 1.5;
-  }
 }

--- a/app/assets/sass/components/_app-card-one-third-column-list.scss
+++ b/app/assets/sass/components/_app-card-one-third-column-list.scss
@@ -1,16 +1,16 @@
 .app-card__one-third-column-list {
-  font-family: "GDS Transport", Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 1.25;
-  width: 100%;
-  margin: 0 0 20px;
+  @include govuk-font($size: 16);
+  margin-bottom: govuk-spacing(4);
+}
+
+@media (min-width: 40.0625em) {
+  .app-card__one-third-column-list {
+    @include govuk-font($size: 19);
+  }
 }
 
 .app-card__one-third-column-list-item {
-  margin-bottom: 10px;
+  margin-bottom: govuk-spacing(2);
 }
 
 .app-card__one-third-column-list-key, .app-card__one-third-column-list-value {
@@ -23,11 +23,4 @@
 
 .app-card__one-third-column-list-value {
   margin: 0;
-}
-
-@media (min-width: 40.0625em) {
-  .app-card__one-third-column-list {
-    font-size: 19px;
-    line-height: 1.5;
-  }
 }

--- a/app/assets/sass/components/_app-card-one-third-column-list.scss
+++ b/app/assets/sass/components/_app-card-one-third-column-list.scss
@@ -1,36 +1,33 @@
 .app-card__one-third-column-list {
-    font-family: "GDS Transport", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 1.25;
-    width: 100%;
-    margin: 0 0 20px;
-  }
-  
-  .app-card__one-third-column-list-item {
-    margin-bottom: 10px;
-  }
-  
-  .app-card__one-third-column-list-key, .app-card__one-third-column-list-value {
-    display: block;
-  }
-  
-  .app-card__one-third-column-list-key {
-    font-weight: 700;
-  }
-  
-  .app-card__one-third-column-list-value {
-    margin: 0;
-  }
-  
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  width: 100%;
+  margin: 0 0 20px;
+}
 
-  
-  @media (min-width: 40.0625em) {
+.app-card__one-third-column-list-item {
+  margin-bottom: 10px;
+}
+
+.app-card__one-third-column-list-key, .app-card__one-third-column-list-value {
+  display: block;
+}
+
+.app-card__one-third-column-list-key {
+  font-weight: 700;
+}
+
+.app-card__one-third-column-list-value {
+  margin: 0;
+}
+
+@media (min-width: 40.0625em) {
   .app-card__one-third-column-list {
-      font-size: 19px;
-      line-height: 1.5;
-  
-    }
+    font-size: 19px;
+    line-height: 1.5;
   }
+}


### PR DESCRIPTION
Update meta list and 2/3rds column list styles to use built in mixins and DRY up code.