### PR TITLE
Show uploaded files in outcome details

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -38,5 +38,9 @@ module.exports = function (env) {
     return DateTime.fromISO(datetimeString).toFormat('d MMM yyyy')
   }
 
+  filters.forceArray = stringOrArray => {
+    return Array.isArray(stringOrArray) ? stringOrArray : [stringOrArray]
+  }
+
   return filters
 }

--- a/app/views/confirm-attendance/_outcome-details.html
+++ b/app/views/confirm-attendance/_outcome-details.html
@@ -1,5 +1,11 @@
 {% set complianceText = case.serviceUserPersonalDetails.firstName + ' was absent' if data['communication'][CRN][sessionId]['did-service-user-comply'] == 'Absent' else data['communication'][CRN][sessionId]['did-service-user-comply']  %}
 
+{% set uploadedFilesHtml %}
+  {% for file in data['communication'][CRN][sessionId]['filenames'] | forceArray %}
+    <a href="#">{{ file }}</a><br />
+  {% endfor %}
+{% endset %}
+
 {{ govukSummaryList({
   classes: 'govuk-!-margin-bottom-9',
   rows: [
@@ -50,12 +56,27 @@
       actions: {
         items: [
           {
-            href: "add-notes",
+            href: "notes",
             text: "Change",
             visuallyHiddenText: "appointment notes"
           }
         ]
       } if showAction
-    }
+    },
+    {
+      key: { text: "Uploaded files" },
+      value: {
+        html: uploadedFilesHtml
+      },
+      actions: {
+        items: [
+          {
+            href: "notes",
+            text: "Change",
+            visuallyHiddenText: "uploaded files"
+          }
+        ]
+      } if showAction
+    } if data['communication'][CRN][sessionId]['filenames'].length > 0
   ]
   }) }}

--- a/app/views/confirm-attendance/notes.html
+++ b/app/views/confirm-attendance/notes.html
@@ -59,13 +59,15 @@
 
   </div>
 
-  <div class="govuk-form-group">
-    <label class="govuk-label govuk-!-font-weight-bold" for="case-note-description">
-      Upload files
-    </label>
-    <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file"
-      aria-describedby="file-upload-1-hint">
-  </div>
+  {{ govukFileUpload({
+    label: {
+      classes: "govuk-label--s",
+      text: "Upload files"
+    },
+    attributes: {
+      multiple: ""
+    }
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'filenames'])) }}
 
   <p class="govuk-hint">
     This will be added to the nDelius contact log.


### PR DESCRIPTION
* Allow multiple files to be uploaded
* Save the filenames of the files being uploaded
* Show links to those files on the check your answers and previous appointment pages

No files are actually uploaded.

https://trello.com/c/mhbdraah/420-make-the-upload-file-button-functional

![Screen Shot 2021-04-21 at 16 20 31](https://user-images.githubusercontent.com/319055/115579024-affc5380-a2bd-11eb-8903-71272616e54f.png)
![Screen Shot 2021-04-21 at 16 20 26](https://user-images.githubusercontent.com/319055/115579030-b1c61700-a2bd-11eb-8bf7-860c06c4100e.png)
