### PR TITLE
Make timeline a little easier to scan

### DIFF
--- a/app/views/case/_appointment-timeline-entry.html
+++ b/app/views/case/_appointment-timeline-entry.html
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-s">
+<h3 class="govuk-heading-m">
   <a class="govuk-!-font-weight-bold govuk-!-margin-right-2" href="/cases/{{ CRN }}/appointments/{{ entry.sessionId }}">{{ entry['type-of-session'] }}</a>
 
   {% if entry['session-counts-towards-rar'] === 'Yes' %}
@@ -12,9 +12,8 @@
   {% elseif entry['did-service-user-comply'] === 'Absent' %}
     {{ govukTag({text: 'Absent', classes: 'govuk-tag--red'}) }}
   {% endif %}
-  <br>
 
-  <div class="govuk-!-margin-top-1">
+  <div class="govuk-!-margin-top-1 govuk-!-font-size-19">
     {{ entry['session-date'] | dateWithYear }} from {{ entry['session-start-time'] }} to {{ entry['session-end-time'] }}
     {% if entry.repeat === 'Yes' %}
       {{ govukTag({text: 'Repeat', classes: 'govuk-tag--turquoise'}) }}

--- a/app/views/case/_appointment-timeline-entry.html
+++ b/app/views/case/_appointment-timeline-entry.html
@@ -1,7 +1,5 @@
 <h3 class="govuk-heading-s">
-  <a class="govuk-!-font-weight-bold govuk-!-margin-right-2" href="/cases/{{ CRN }}/appointments/{{ entry.sessionId }}">
-    {{ entry['type-of-session'] }}
-  </a>
+  <a class="govuk-!-font-weight-bold govuk-!-margin-right-2" href="/cases/{{ CRN }}/appointments/{{ entry.sessionId }}">{{ entry['type-of-session'] }}</a>
 
   {% if entry['session-counts-towards-rar'] === 'Yes' %}
     {{ govukTag({text: 'RAR', classes: 'govuk-tag--purple'}) }}

--- a/app/views/case/_appointment-timeline-entry.html
+++ b/app/views/case/_appointment-timeline-entry.html
@@ -46,17 +46,17 @@
 {% set hasAppointmentTimePassed = isInThePast({date: entry['session-date'], time: entry['session-end-time']}) %}
 {% set shouldPromptToConfirmAttendance = (not hasAttendanceAlreadyBeenConfirmed) and hasAppointmentTimePassed %}
 
-{% if entry['session-notes'] or shouldPromptToConfirmAttendance %}
-  <div class="note-panel">
-    {% if shouldPromptToConfirmAttendance  %}
-      {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/' + entry.sessionId + '">Confirm attendance</a>') }}
-    {% endif %}
+{% if shouldPromptToConfirmAttendance  %}
+  {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/' + entry.sessionId + '">Confirm attendance</a>') }}
+{% endif %}
 
-    {% set truncatedContents = entry['session-notes'] | truncate(300) %}
-    {% set isTruncated = entry['session-notes'] and (truncatedContents !== entry['session-notes']) %}
-    <p class="govuk-body {{ 'govuk-!-margin-bottom-0' if not isTruncated }}">{{ truncatedContents | nl2br | safe }}</p>
-    {% if isTruncated %}
-      <a href="/cases/{{ CRN }}/appointments/{{ entry.sessionId }}">View full details</a>
-    {% endif %}
-  </div>
+{% if entry['session-notes'] %}
+<div class="note-panel">
+  {% set truncatedContents = entry['session-notes'] | truncate(300) %}
+  {% set isTruncated = entry['session-notes'] and (truncatedContents !== entry['session-notes']) %}
+  <p class="govuk-body {{ 'govuk-!-margin-bottom-0' if not isTruncated }}">{{ truncatedContents | nl2br | safe }}</p>
+  {% if isTruncated %}
+    <a href="/cases/{{ CRN }}/appointments/{{ entry.sessionId }}">View full details</a>
+  {% endif %}
+</div>
 {% endif %}

--- a/app/views/case/_communication-timeline-entry.html
+++ b/app/views/case/_communication-timeline-entry.html
@@ -1,9 +1,8 @@
-<h3 class="govuk-heading-s">
+<h3 class="govuk-heading-m">
   <a class="govuk-!-font-weight-bold govuk-!-margin-right-2" href="/cases/{{ CRN }}/other-communication/{{ entry.sessionId }}">
     {{ entry.type }} to {{ case.serviceUserPersonalDetails.name if entry.to === 'Service user' else entry.to }}
   </a>
-  <br>
-  <div class="govuk-!-margin-top-1">
+  <div class="govuk-!-margin-top-1 govuk-!-font-size-19">
   {{ entry.timestamp | dateWithYear }}
   </div>
 </h3>

--- a/app/views/case/address-book-professional.html
+++ b/app/views/case/address-book-professional.html
@@ -41,7 +41,9 @@
     {% set hr = joiner('<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">') %}
 
     {% for contact in case.professionalContacts %}
-      {{ hr() | safe }}
+      {% if loop.index != 1 %}
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      {% endif %}
 
       <div class="govuk-!-margin-bottom-7">
         <h2 class="govuk-heading-m">{{ contact.name }}</h2>

--- a/app/views/case/communication.html
+++ b/app/views/case/communication.html
@@ -78,8 +78,7 @@
 
     {% set hr = joiner('<hr>') %}
     {% for entry in communicationEntries(CRN, data, {category: category}) %}
-
-      {{ hr() | safe }}
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       {% if entry.type === 'Appointment' %}
         {% include "case/_appointment-timeline-entry.html" %}


### PR DESCRIPTION
| Before | After |
|--|--|
| ![Screen Shot 2021-04-21 at 17 03 06](https://user-images.githubusercontent.com/319055/115585456-880fee80-a2c3-11eb-9df8-139ef2da0fb5.png) |  ![Screen Shot 2021-04-21 at 17 02 43](https://user-images.githubusercontent.com/319055/115585453-86dec180-a2c3-11eb-80f0-a8e4542f87e3.png) |

Also includes a fix for the red banner showing on a grey box:
![Screen Shot 2021-04-21 at 17 09 52](https://user-images.githubusercontent.com/319055/115586406-767b1680-a2c4-11eb-82a2-663aeac92d9d.png)

