### PR TITLE
Display the real "recently allocated case" number instead of hard-coded number

### DIFF
--- a/app/views/cases/index.html
+++ b/app/views/cases/index.html
@@ -34,7 +34,7 @@ My cases
     </li>
     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
       <a class="govuk-tabs__tab" href="recently-allocated">
-        Recently allocated (3)
+        Recently allocated ({{ data.cases.length }})
       </a>
     </li>
   </ul>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23801/115669909-b97acf80-a340-11eb-938b-b005333bd3df.png)
