### PR TITLE
Add calendar note page

### DIFF
--- a/app/utils/arrange-a-session-wizard-paths.js
+++ b/app/utils/arrange-a-session-wizard-paths.js
@@ -14,6 +14,8 @@ function arrangeSessionWizardPaths (req) {
     `/arrange-a-session/${CRN}/${sessionId}/when`,
     `/arrange-a-session/${CRN}/${sessionId}/rar`,
     `/arrange-a-session/${CRN}/${sessionId}/rar-categories`,
+    `/arrange-a-session/${CRN}/${sessionId}/add-notes`,
+    `/arrange-a-session/${CRN}/${sessionId}/notes`,
     `/arrange-a-session/${CRN}/${sessionId}/check`,
     `/arrange-a-session/${CRN}/${sessionId}/confirmation`,
     `/cases/${CRN}`,
@@ -40,6 +42,12 @@ function arrangeSessionWizardForks (req) {
     {
       currentPath: `/arrange-a-session/${CRN}/${sessionId}/rar`,
       storedData: ['communication', CRN, sessionId, 'session-counts-towards-rar'],
+      values: ['No'],
+      forkPath: `/arrange-a-session/${CRN}/${sessionId}/add-notes`
+    },
+    {
+      currentPath: `/arrange-a-session/${CRN}/${sessionId}/add-notes`,
+      storedData: ['communication', CRN, sessionId, 'add-notes'],
       values: ['No'],
       forkPath: `/arrange-a-session/${CRN}/${sessionId}/check`
     },

--- a/app/views/arrange-a-session/_session-details.html
+++ b/app/views/arrange-a-session/_session-details.html
@@ -97,7 +97,7 @@
       } if showAction
     } if session.summary.rarCategory,
     {
-      key: { text: "Counts towards RAR?" },
+      key: { text: "RAR activity" },
       value: { text: 'Yes' if session.summary.countsTowardsRAR else 'No' },
       actions: {
         items: [
@@ -110,14 +110,14 @@
       } if showAction
     } if not session.summary.countsTowardsRAR,
     {
-      key: { text: "Calendar note" },
+      key: { text: "Appointment notes" },
       value: { text: data['communication'][CRN][sessionId]['session-notes'] or 'None' },
       actions: {
         items: [
           {
             href: arrangeSessionPath + "/rar",
             text: "Change",
-            visuallyHiddenText: "calendar note"
+            visuallyHiddenText: "appointment notes"
           }
         ]
       } if showAction

--- a/app/views/arrange-a-session/add-notes.html
+++ b/app/views/arrange-a-session/add-notes.html
@@ -1,0 +1,29 @@
+{% extends "_wizard-form.html" %}
+{% set title = "Would you like to add notes about this appointment?" %}
+{% set buttonText = 'Save and continue' %}
+
+{% block form %}
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: title,
+           classes: "govuk-label--xl",
+           isPageHeading: true
+         }
+       },
+       hint: {
+         html: 'Notes can also be added later'
+       },
+       items: [
+         {
+           text: 'Yes',
+           value: 'Yes'
+         },
+         {
+           text: 'No',
+           value: 'No'
+         }
+       ]
+       } | decorateFormAttributes(['communication', CRN, sessionId, 'add-notes']))
+  }}
+{% endblock %}

--- a/app/views/arrange-a-session/add-notes.html
+++ b/app/views/arrange-a-session/add-notes.html
@@ -11,17 +11,12 @@
            isPageHeading: true
          }
        },
-       hint: {
-         html: 'Notes can also be added later'
-       },
        items: [
          {
-           text: 'Yes',
-           value: 'Yes'
+           text: 'Yes'
          },
          {
-           text: 'No',
-           value: 'No'
+           text: 'No (Notes can be added later)'
          }
        ]
        } | decorateFormAttributes(['communication', CRN, sessionId, 'add-notes']))

--- a/app/views/arrange-a-session/check.html
+++ b/app/views/arrange-a-session/check.html
@@ -1,7 +1,7 @@
 {% extends "_wizard-form.html" %}
 {% set rearranging = data['communication'][CRN][sessionId]['rearrange-or-cancel'] %}
 {% set buttonText = 'Rearrange appointment' if rearranging else 'Arrange appointment' %}
-{% set title = 'Check your answers and confirm appointment' %}
+{% set title = 'Check your answers' %}
 
 {% block form %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>

--- a/app/views/arrange-a-session/notes.html
+++ b/app/views/arrange-a-session/notes.html
@@ -1,0 +1,24 @@
+{% extends "_wizard-form.html" %}
+{% set title = "Add appointment notes" %}
+{% set buttonText = 'Save and continue' %}
+
+{% block form %}
+  <div class="govuk-form-group">
+    
+    {{ govukTextarea({
+      name: "notes",
+      id: "notes",
+      label: {
+        text: "Add appointment notes",
+        classes: "govuk-label--xl",
+        isPageHeading: true
+      },
+      rows: 10
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'session-notes'])) }}
+
+  </div>
+
+  <p class="govuk-hint">
+    This will be added to the nDelius contact log.
+  </p>
+{% endblock %}

--- a/app/views/arrange-a-session/rar-categories.html
+++ b/app/views/arrange-a-session/rar-categories.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set title = 'What will this appointment count towards?' %}
+{% set buttonText = 'Save and continue' %}
 
 {% block form %}
   {% set rarRadioItems = [] %}

--- a/app/views/arrange-a-session/rar.html
+++ b/app/views/arrange-a-session/rar.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set title = 'Will this appointment count towards RAR?' %}
+{% set buttonText = 'Save and continue' %}
 
 {% block form %}
   {{ govukRadios({
@@ -23,10 +24,4 @@
       ]
   } | decorateFormAttributes(['communication', CRN, sessionId, 'session-counts-towards-rar'])) }}
 
-  {{ govukTextarea({
-    label: {
-      text: 'Add a calendar note (optional)',
-      classes: 'govuk-label--l'
-    }
-  } | decorateFormAttributes(['communication', CRN, sessionId, 'session-notes'])) }}
 {% endblock %}

--- a/app/views/confirm-attendance/_outcome-details.html
+++ b/app/views/confirm-attendance/_outcome-details.html
@@ -10,21 +10,21 @@
   classes: 'govuk-!-margin-bottom-9',
   rows: [
     {
-      key: { text: case.serviceUserPersonalDetails.firstName + " complied?" },
+      key: { text: "Complied" },
       value: { text: complianceText },
       actions: {
         items: [
           {
             href: "compliance",
             text: "Change",
-            visuallyHiddenText: "compliance"
+            visuallyHiddenText: "complied"
           }
         ]
       } if showAction
     },
     {
       key: { text: "RAR activity" },
-      value: { text: data['communication'][CRN][sessionId]['session-rar-category'] if data['communication'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes' else 'None'  },
+      value: { text: data['communication'][CRN][sessionId]['session-rar-category'] if data['communication'][CRN][sessionId]['session-counts-towards-rar'] == 'Yes' else 'No'  },
       actions: {
         items: [
           {

--- a/app/views/confirm-attendance/add-notes.html
+++ b/app/views/confirm-attendance/add-notes.html
@@ -11,19 +11,15 @@
            isPageHeading: true
          }
        },
-       hint: {
-         html: 'Notes can also be added later'
-       },
        items: [
          {
-           text: 'Yes',
-           value: 'Yes'
+           text: 'Yes'
          },
          {
-           text: 'No',
-           value: 'No'
+           text: 'No (Notes can be added later)'
          }
        ]
        } | decorateFormAttributes(['communication', CRN, sessionId, 'add-notes']))
   }}
 {% endblock %}
+

--- a/app/views/confirm-attendance/notes.html
+++ b/app/views/confirm-attendance/notes.html
@@ -3,8 +3,19 @@
 {% set buttonText = 'Save and continue' %}
 
 {% block form %}
-<h1 class="govuk-heading-xl">Add appointment notes</h1>
   <div class="govuk-form-group">
+
+    {{ govukTextarea({
+      name: "notes",
+      id: "notes",
+      label: {
+        text: "Add appointment notes",
+        classes: "govuk-label--xl",
+        isPageHeading: true
+      },
+      rows: 10
+    } | decorateFormAttributes(['communication', CRN, sessionId, 'session-notes'])) }}
+
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
@@ -50,13 +61,6 @@
         </h2>
       </div>
     </details>
-
-    {{ govukTextarea({
-      name: "notes",
-      id: "notes",
-      rows: 10
-    } | decorateFormAttributes(['communication', CRN, sessionId, 'session-notes'])) }}
-
   </div>
 
   {{ govukFileUpload({

--- a/app/views/confirm-attendance/rar-categories.html
+++ b/app/views/confirm-attendance/rar-categories.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set title = 'What should this appointment count towards?' %}
+{% set buttonText = 'Save and continue' %}
 
 {% block form %}
   {% set rarRadioItems = [] %}

--- a/app/views/confirm-attendance/rar.html
+++ b/app/views/confirm-attendance/rar.html
@@ -1,5 +1,6 @@
 {% extends "_wizard-form.html" %}
 {% set title = 'Should this appointment count towards RAR?' %}
+{% set buttonText = 'Save and continue' %}
 
 {% block form %}
   {{ govukRadios({


### PR DESCRIPTION
### Arrange appointment and confirm attendance RAR questions were missing 'Save and continue' button.

**Before:**
![Screenshot 2021-04-22 at 16 39 58](https://user-images.githubusercontent.com/6122118/115743420-91fc2500-a389-11eb-84dc-d60c58540c46.png)

**After:**
![Screenshot 2021-04-22 at 16 40 09](https://user-images.githubusercontent.com/6122118/115743452-99bbc980-a389-11eb-9fa8-1b09bd7291d1.png)

### Removed calendar note from arrange appointment RAR page.

**Before**
![Screenshot 2021-04-22 at 16 42 08](https://user-images.githubusercontent.com/6122118/115743629-bfe16980-a389-11eb-8e79-b0006951da4b.png)

**After**
![Screenshot 2021-04-22 at 16 42 00](https://user-images.githubusercontent.com/6122118/115743664-c66fe100-a389-11eb-804d-4a166cae9ca0.png)

### Fix textarea label spacing on Confirm attendance notes page.

**Before**
![Screenshot 2021-04-22 at 16 43 16](https://user-images.githubusercontent.com/6122118/115743866-f6b77f80-a389-11eb-8f69-74ce42072cd7.png)

**After**
(I moved the `details` to under the `textarea` as a quick fix)
![Screenshot 2021-04-22 at 16 43 36](https://user-images.githubusercontent.com/6122118/115743983-0cc54000-a38a-11eb-85e3-5fc54ec185d8.png)

### Removed extra content from Check answers H1
This was a speculative issue, we thought users may then the green button saying 'Arrange appointment' may be thought as starting a new transaction, but it may be best to test if this is a real concern. 

**Before**
![Screenshot 2021-04-22 at 16 45 23](https://user-images.githubusercontent.com/6122118/115744254-4f871800-a38a-11eb-88a4-4e020305ad22.png)

**After**
![Screenshot 2021-04-22 at 16 45 10](https://user-images.githubusercontent.com/6122118/115744273-54e46280-a38a-11eb-875a-da2630c29b54.png)

### Updated labels and values on arrange appointment and confirm attendance Check answers pages
This was to try and avoid using questions in the labels, and for consistency between the two transactions

**Before**
Arrange an appointment
![Screenshot 2021-04-22 at 16 50 54](https://user-images.githubusercontent.com/6122118/115744977-f075d300-a38a-11eb-828c-e62200949121.png)

Confirm attendance
![Screenshot 2021-04-22 at 16 47 15](https://user-images.githubusercontent.com/6122118/115744602-9d9c1b80-a38a-11eb-950d-de77492f32dc.png)

**After**
Arrange an appointment 
![Screenshot 2021-04-22 at 16 49 51](https://user-images.githubusercontent.com/6122118/115744834-d3d99b00-a38a-11eb-884c-d83c53c99c38.png)

Confirm attendance
![Screenshot 2021-04-22 at 16 47 43](https://user-images.githubusercontent.com/6122118/115744654-ad1b6480-a38a-11eb-8ce0-1d3770335dfc.png)

### Add a separate appointment notes page
We discussed replacing content of 'Calendar note' with 'Appointment notes' and making it consistent with confirming attendance. However, I've removed the `details` about CRISS as it's not relevant before an appointment, and I've also removed file upload (but can add back in). I've added a forking question to be consistent. 

**Before**
![Screenshot 2021-04-22 at 16 52 43](https://user-images.githubusercontent.com/6122118/115745268-2dda6080-a38b-11eb-8e60-ae53d85bd134.png)

**After**
![Screenshot 2021-04-22 at 16 53 19](https://user-images.githubusercontent.com/6122118/115745509-67ab6700-a38b-11eb-8d9d-f9f74e1d3d5d.png)

![Screenshot 2021-04-22 at 16 53 23](https://user-images.githubusercontent.com/6122118/115745519-6b3eee00-a38b-11eb-9f17-ddac93b26556.png)


