### PR TITLE
Time-related bug-fixes

### DIFF
--- a/app/views/case/_appointment-timeline-entry.html
+++ b/app/views/case/_appointment-timeline-entry.html
@@ -43,8 +43,8 @@
 </dl>
 
 {% set hasAttendanceAlreadyBeenConfirmed = not not entry['did-service-user-comply'] %}
-{% set hasAppointmentTimePassed = isInThePast({date: entry['session-date'], time: entry['session-end-time']}) %}
-{% set shouldPromptToConfirmAttendance = (not hasAttendanceAlreadyBeenConfirmed) and hasAppointmentTimePassed %}
+{% set hasAppointmentStartTimePassed = isInThePast({date: entry['session-date'], time: entry['session-start-time']}) %}
+{% set shouldPromptToConfirmAttendance = (not hasAttendanceAlreadyBeenConfirmed) and hasAppointmentStartTimePassed %}
 
 {% if shouldPromptToConfirmAttendance  %}
   {{ appWarningBanner('Attendance not confirmed. <a href="/confirm-attendance/' + CRN + '/' + entry.sessionId + '">Confirm attendance</a>') }}

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% set entry = data['communication'][CRN][sessionId] %}
-{% set appointmentType = 'previous' if isInThePast({date: entry['session-date'], time: entry['session-end-time']}) else 'upcoming' %}
+{% set appointmentType = 'previous' if isInThePast({date: entry['session-date'], time: entry['session-start-time']}) else 'upcoming' %}
 {% set title = entry['type-of-session'] + ' details' %}
 {% block pageTitle %}{{ title }}{% endblock %}
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -89,7 +89,7 @@ exports.endDateTime = (appointment) => {
     timeString = appointment['session-end-time']
   }
 
-  return DateTime.fromString(`${appointment['session-date']} ${timeString}`, 'yyyy-MM-dd h:mma', {zone: 'utc'})
+  return DateTime.fromString(`${appointment['session-date']} ${timeString}`, 'yyyy-MM-dd h:mma')
 }
 
 const filterEntriesByCategory = (category) => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -80,13 +80,13 @@ exports.isInThePast = (params) => {
   return DateTime.now() > exports.dateTimeFrom(params)
 }
 
-exports.endDateTime = (appointment) => {
+exports.startDateTime = (appointment) => {
   var timeString
   // normalise 4pm => 4:00pm
-  if (!appointment['session-end-time'].includes(':')) {
-    timeString = appointment['session-end-time'].replace(/(\d+)(am|pm)/, '$1:00$2')
+  if (!appointment['session-start-time'].includes(':')) {
+    timeString = appointment['session-start-time'].replace(/(\d+)(am|pm)/, '$1:00$2')
   } else {
-    timeString = appointment['session-end-time']
+    timeString = appointment['session-start-time']
   }
 
   return DateTime.fromString(`${appointment['session-date']} ${timeString}`, 'yyyy-MM-dd h:mma')
@@ -122,7 +122,7 @@ exports.futureAppointments = (CRN, data) => {
 
 exports.nextAppointment = (CRN, data) => {
   return exports.futureAppointments(CRN, data)
-    .sort((a, b) => exports.endDateTime(a) < exports.endDateTime(b) ? -1 : 1)
+    .sort((a, b) => exports.startDateTime(a) < exports.startDateTime(b) ? -1 : 1)
     .shift()
 }
 


### PR DESCRIPTION
Time-related bug-fixes:

- the prompt to confirm an appointment should appear as soon as the start time has passed
  - on the Communication page
  - on the appointment details page
- treat all times as local time (rather than GMT/UTC) to avoid unexpected behaviour during the BST months
- sort upcoming appointments by their start time, not by their end time (🤦 )
