### PR TITLE
Add a thing flow: recording appointment attendance

### DIFF
--- a/app/routes/cases.js
+++ b/app/routes/cases.js
@@ -20,8 +20,13 @@ module.exports = router => {
   })
 
   router.post('/cases/:CRN/communication/add', (req, res) => {
-    const typeOfOtherComms = req.session.data['add-communication'][req.params.CRN]['type-of-new-other-communication']
-    res.redirect(`/add-other-communication/${req.params.CRN}/new?type=${typeOfOtherComms}`)
+    const typeOfThingToAdd = req.session.data['add-communication'][req.params.CRN]['type-of-thing-to-add']
+    if (typeOfThingToAdd === 'confirm-attendance') {
+      res.redirect(`/confirm-attendance/${req.params.CRN}`)
+    } else {
+      const typeOfOtherComms = req.session.data['add-communication'][req.params.CRN]['type-of-new-other-communication']
+      res.redirect(`/add-other-communication/${req.params.CRN}/new?type=${typeOfOtherComms}`)
+    }
   })
 
   router.all('/cases/:CRN/communication/:category', function (req, res) {

--- a/app/routes/confirm-attendance.js
+++ b/app/routes/confirm-attendance.js
@@ -1,3 +1,5 @@
+const { getDataValue } = require('../utils/helpers')
+
 const {
   confirmAttendanceWizardPaths,
   confirmAttendanceWizardForks
@@ -16,6 +18,17 @@ module.exports = router => {
     })
     next()
   })
+
+  router.get('/confirm-attendance/:CRN', function (req, res) {
+    res.locals.CRN = req.params.CRN
+    res.render(`confirm-attendance/index`, { paths: confirmAttendanceWizardPaths(req) })
+  })
+
+  router.post('/confirm-attendance/:CRN', function (req, res) {
+    const sessionId = getDataValue(req.session.data, ['confirm-attendance', req.params.CRN, 'appointment-to-confirm'])
+    res.redirect(`/confirm-attendance/${req.params.CRN}/${sessionId}`)
+  })
+
 
   router.get('/confirm-attendance/:CRN/:sessionId/:view', function (req, res) {
     res.render(`confirm-attendance/${req.params.view}`, { paths: confirmAttendanceWizardPaths(req) })

--- a/app/utils/confirm-attendance-wizard-paths.js
+++ b/app/utils/confirm-attendance-wizard-paths.js
@@ -20,7 +20,9 @@ function confirmAttendanceWizardPaths (req) {
     `${basePath}/notes`,
     `${basePath}/check`,
     `${basePath}/confirmation`,
-    `/arrange-a-session/${CRN}/start`
+    `/arrange-a-session/${CRN}/start`,
+    `/cases/${CRN}/communication/add`,
+    `/confirm-attendance/${CRN}`
   ]
 
   return nextAndBackPaths(paths, req)

--- a/app/views/add-other-communication/new.html
+++ b/app/views/add-other-communication/new.html
@@ -1,12 +1,13 @@
 {% extends "_wizard-form.html" %}
 {%- set label -%}
-  {%- if type === 'phonecall' -%}
+  {%- switch type -%}
+  {%- case 'phonecall' -%}
     phone call
-  {%- elif type === 'text' -%}
+  {%- case 'text' -%}
     text message
-  {%- elif type === 'email' -%}
+  {%- case 'email' -%}
     email
-  {%- endif -%}
+  {%- endswitch -%}
 {%- endset %}
 {% set title = ('Add an ' + label if label === 'email' else 'Add a ' + label ) %}
 

--- a/app/views/case/add-communication.html
+++ b/app/views/case/add-communication.html
@@ -8,6 +8,25 @@
 {% endblock %}
 
 {% block form %}
+  {% set otherCommunicationHTML %}
+    {{ govukRadios({
+      items: [
+        {
+          text: "Phone call",
+          value: 'phonecall'
+        },
+        {
+          text: "Text message",
+          value: 'text'
+        },
+        {
+          text: "Email",
+          value: 'email'
+        }
+      ]
+    } | decorateFormAttributes(['add-communication', CRN, 'type-of-new-other-communication'])) }}
+  {% endset %}
+
   {{ govukRadios({
     fieldset: {
       legend: {
@@ -18,18 +37,14 @@
     },
     items: [
       {
-        text: "Phone call",
-        value: 'phonecall'
-      },
+        text: "Appointment attendance",
+        value: 'confirm-attendance'
+      } if previousAppointmentsWithoutOutcomes(CRN, data).length > 0,
       {
-        text: "Text message",
-        value: 'text'
-      },
-      {
-        text: "Email",
-        value: 'email'
+        text: "Other communication",
+        value: 'other',
+        conditional: { html: otherCommunicationHTML }
       }
     ]
-  } | decorateFormAttributes(['add-communication', CRN, 'type-of-new-other-communication'])) }}
-
+  } | decorateFormAttributes(['add-communication', CRN, 'type-of-thing-to-add'])) }}
 {% endblock %}

--- a/app/views/confirm-attendance/index.html
+++ b/app/views/confirm-attendance/index.html
@@ -1,0 +1,27 @@
+{% extends "_wizard-form.html" %}
+{% set title = "When was the appointment?" %}
+{% set buttonText = 'Save and continue' %}
+
+{% block form %}
+  {% set appointmentRadioItems = [] %}
+
+  {% for appointment in previousAppointmentsWithoutOutcomes(CRN, data) %}
+    {% set appointmentRadioItems = (appointmentRadioItems.push({
+      text: appointment['type-of-session'] + ' – ' + appointment['session-date'] | dateWithDayAndWithoutYear +
+              ' from ' + appointment['session-start-time'] + ' to ' + appointment['session-end-time'],
+      value: appointment.sessionId
+    }), appointmentRadioItems) %}
+  {% endfor %}
+
+  {{ govukRadios({
+       fieldset: {
+         legend: {
+           text: title,
+           classes: "govuk-label--xl",
+           isPageHeading: true
+         }
+       },
+       items: appointmentRadioItems
+       } | decorateFormAttributes(['confirm-attendance', CRN, 'appointment-to-confirm']))
+  }}
+{% endblock %}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -126,6 +126,11 @@ exports.nextAppointment = (CRN, data) => {
     .shift()
 }
 
+exports.previousAppointmentsWithoutOutcomes = (CRN, data) => {
+  return exports.communicationEntries(CRN, data, {category: 'previous'})
+    .filter(entry => entry['did-service-user-comply'] === undefined)
+}
+
 exports.addHelpers = function (env) {
   env.addGlobal('progressPercentage', exports.progressPercentage)
 
@@ -146,6 +151,8 @@ exports.addHelpers = function (env) {
   env.addGlobal('isInThePast', exports.isInThePast)
 
   env.addGlobal('nextAppointment', exports.nextAppointment)
+
+  env.addGlobal('previousAppointmentsWithoutOutcomes', exports.previousAppointmentsWithoutOutcomes)
 
   env.addGlobal('today', exports.today)
 }


### PR DESCRIPTION
Extend the 'Add communication' screen to allow recording appointment outcomes:

## What are you adding?

![image](https://user-images.githubusercontent.com/23801/115845790-22357b00-a419-11eb-87cd-ff3751141cd9.png)

![image](https://user-images.githubusercontent.com/23801/115845846-35484b00-a419-11eb-8ded-598b31dd7085.png)

## When was the appointment?

![image](https://user-images.githubusercontent.com/23801/115845886-3f6a4980-a419-11eb-9d5e-c5c7f83785ad.png)
