### PR TITLE
Show success flash after editing appointment notes

### DIFF
--- a/app/routes/cases.js
+++ b/app/routes/cases.js
@@ -36,7 +36,7 @@ module.exports = router => {
 
   router.all('/cases/:CRN/appointments/:sessionId', function (req, res) {
     res.locals.sessionId = req.params.sessionId
-    res.render('case/appointment')
+    res.render('case/appointment', { messages: req.flash('success') })
   })
 
   router.get('/cases/:CRN/appointments/:sessionId/notes', function (req, res) {
@@ -45,6 +45,7 @@ module.exports = router => {
   })
 
   router.post('/cases/:CRN/appointments/:sessionId/notes', function (req, res) {
+    req.flash('success', 'Appointment notes saved')
     res.redirect(`/cases/${req.params.CRN}/appointments/${req.params.sessionId}`)
   })
 

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -6,6 +6,11 @@
 
 {% block content %}
 
+{{ govukNotificationBanner({
+  text: messages[0],
+  type: 'success'
+}) if messages.length > 0 }}
+
 {% include "case/_case-service-user-banner.html" %}
 
 {{ govukBackLink({

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -3,33 +3,34 @@
 
 {% extends "govuk/template.njk" %}
 
-{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
-{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
-{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
-{% from "govuk/components/button/macro.njk"           import govukButton %}
-{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
-{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
-{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
-{% from "govuk/components/details/macro.njk"          import govukDetails %}
-{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
-{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
-{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
-{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
-{% from "govuk/components/input/macro.njk"            import govukInput %}
-{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
-{% from "govuk/components/panel/macro.njk"            import govukPanel %}
-{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
-{% from "govuk/components/radios/macro.njk"           import govukRadios %}
-{% from "govuk/components/select/macro.njk"           import govukSelect %}
-{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
-{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
-{% from "govuk/components/table/macro.njk"            import govukTable %}
-{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
-{% from "govuk/components/tag/macro.njk"              import govukTag %}
-{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
-{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
+{% from "govuk/components/accordion/macro.njk"           import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"           import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"         import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"              import govukButton %}
+{% from "govuk/components/character-count/macro.njk"     import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"          import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"          import govukDateInput %}
+{% from "govuk/components/details/macro.njk"             import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"       import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"       import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"            import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"         import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"               import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"          import govukInsetText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/panel/macro.njk"               import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"        import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"              import govukRadios %}
+{% from "govuk/components/select/macro.njk"              import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"           import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"        import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"               import govukTable %}
+{% from "govuk/components/tabs/macro.njk"                import govukTabs %}
+{% from "govuk/components/tag/macro.njk"                 import govukTag %}
+{% from "govuk/components/textarea/macro.njk"            import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"        import govukWarningText %}
 
-{% from "_components/warning-banner/macro.njk"        import appWarningBanner %}
+{% from "_components/warning-banner/macro.njk"           import appWarningBanner %}
 
 {% block head %}
   {% include "includes/head.html" %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4842,9 +4842,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.9.1.tgz",
-      "integrity": "sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
+      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
     },
     "govuk_frontend_toolkit": {
       "version": "7.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,6 +2245,11 @@
         "utils-merge": "1.0.1"
       }
     },
+    "connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA="
+    },
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "body-parser": "^1.14.1",
     "browser-sync": "^2.26.14",
     "client-sessions": "^0.8.0",
+    "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.3",
     "cross-spawn": "^6.0.5",
     "del": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.9.1",
+    "govuk-frontend": "^3.11.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const path = require('path')
 const bodyParser = require('body-parser')
 const dotenv = require('dotenv')
 const express = require('express')
+const flash = require('connect-flash')
 const nunjucks = require('nunjucks')
 const sessionInCookie = require('client-sessions')
 const sessionInMemory = require('express-session')
@@ -142,6 +143,8 @@ app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({
   extended: true
 }))
+
+app.use(flash())
 
 // Set up v6 app for backwards compatibility
 if (useV6) {


### PR DESCRIPTION
Display a banner to confirm that the user has successfully updated the appointment notes:

![image](https://user-images.githubusercontent.com/23801/115905277-c6d9ac00-a45d-11eb-9543-b1c78210cca3.png)

## Changes

- Update `govuk-frontend` to v3.11 in order to pick up the [notifications banner component](https://design-system.service.gov.uk/components/notification-banner/)
- Add the `connect-flash` package, which introduces flash middleware into the app
- Wire in the success banner on the appointment page

## Questions

Do we need this functionality at all?
Is the banner displayed in the right place on the page?
