### PR TITLE
Insert multiple repeat appointments

### DIFF
--- a/app/models/arranged-session.js
+++ b/app/models/arranged-session.js
@@ -1,6 +1,8 @@
 const path = require('path')
 const contactTypes = require(path.join(__dirname, '../data/reference/contact-types.json'))
 const { RARCategories } = require(path.join(__dirname, './rar-categories.js'))
+const { generateRandomString } = require('../utils/helpers')
+const { DateTime } = require('luxon-business-days')
 
 class ArrangedSession {
   constructor (params) {
@@ -55,6 +57,18 @@ class ArrangedSession {
 
   get contactType () {
     return contactTypes[this.rarCategories.contactTypeCode]
+  }
+
+  static generateRepeatedAppointments (appointment) {
+    const numberOfRepeatedAppts = (appointment['repeating'] === 'Yes' ? 3 : 0)
+
+    return Array(numberOfRepeatedAppts).fill().map((_, i) => {
+      var clonedAppointment = Object.assign({}, appointment)
+      return Object.assign(clonedAppointment, {
+        sessionId: generateRandomString(),
+        'session-date': DateTime.fromISO(appointment['session-date']).plus({weeks: i + 1}).toISODate()
+      })
+    })
   }
 }
 

--- a/app/models/arranged-session.js
+++ b/app/models/arranged-session.js
@@ -59,8 +59,8 @@ class ArrangedSession {
     return contactTypes[this.rarCategories.contactTypeCode]
   }
 
-  static generateRepeatedAppointments (appointment) {
-    const numberOfRepeatedAppts = (appointment['repeating'] === 'Yes' ? 3 : 0)
+  static generateRepeatedWeeklyAppointments (appointment, number = 3) {
+    const numberOfRepeatedAppts = (appointment['repeating'] === 'Yes' ? number : 0)
 
     return Array(numberOfRepeatedAppts).fill().map((_, i) => {
       var clonedAppointment = Object.assign({}, appointment)

--- a/app/models/arranged-session.js
+++ b/app/models/arranged-session.js
@@ -61,13 +61,16 @@ class ArrangedSession {
 
   static generateRepeatedWeeklyAppointments (appointment, number = 3) {
     const numberOfRepeatedAppts = (appointment['repeating'] === 'Yes' ? number : 0)
+    return Array.from(Array(numberOfRepeatedAppts)).map((_, i) => {
+      return this.generateRepeatAppointment({appointment: appointment, weeksInFuture: i+1})
+    })
+  }
 
-    return Array(numberOfRepeatedAppts).fill().map((_, i) => {
-      var clonedAppointment = Object.assign({}, appointment)
-      return Object.assign(clonedAppointment, {
-        sessionId: generateRandomString(),
-        'session-date': DateTime.fromISO(appointment['session-date']).plus({weeks: i + 1}).toISODate()
-      })
+  static generateRepeatAppointment (params) {
+    var clonedAppointment = Object.assign({}, params.appointment)
+    return Object.assign(clonedAppointment, {
+      sessionId: generateRandomString(),
+      'session-date': DateTime.fromISO(clonedAppointment['session-date']).plus({weeks: params.weeksInFuture}).toISODate()
     })
   }
 }

--- a/app/routes/arrange-a-session.js
+++ b/app/routes/arrange-a-session.js
@@ -9,6 +9,8 @@ const {
   arrangeSessionWizardForks
 } = require('../utils/arrange-a-session-wizard-paths')
 
+const { ArrangedSession } = require('../models/arranged-session.js')
+
 module.exports = router => {
   router.get('/arrange-a-session/:CRN/start', (req, res) => {
     const sessionId = generateRandomString()
@@ -23,6 +25,18 @@ module.exports = router => {
         req.params.sessionId,
         'confirmed'
       ], true)
+
+    const originalAppointment = req.session.data['communication'][req.params.CRN][req.params.sessionId]
+    const repeatAppointments = ArrangedSession.generateRepeatedAppointments(originalAppointment)
+
+    repeatAppointments.forEach(appointment => {
+      setDataValue(req.session.data,
+        [
+          'communication',
+          req.params.CRN,
+          appointment.sessionId,
+        ], appointment)
+    })
     next()
   })
 

--- a/app/routes/arrange-a-session.js
+++ b/app/routes/arrange-a-session.js
@@ -27,7 +27,7 @@ module.exports = router => {
       ], true)
 
     const originalAppointment = req.session.data['communication'][req.params.CRN][req.params.sessionId]
-    const repeatAppointments = ArrangedSession.generateRepeatedAppointments(originalAppointment)
+    const repeatAppointments = ArrangedSession.generateRepeatedWeeklyAppointments(originalAppointment, 3)
 
     repeatAppointments.forEach(appointment => {
       setDataValue(req.session.data,

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -3,7 +3,7 @@ const setKeypath = require('keypather/set')
 
 const generateRandomString = (length) => {
   length = length || 3
-  return (Number(new Date())).toString(36).slice(-length).toUpperCase()
+  return Math.random().toString(36).substr(2, length)
 }
 
 const getDataValue = (data, sections) => {

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -3,7 +3,7 @@ const setKeypath = require('keypather/set')
 
 const generateRandomString = (length) => {
   length = length || 3
-  return Math.random().toString(36).substr(2, length)
+  return Math.random().toString(36).substr(2, length).toUpperCase()
 }
 
 const getDataValue = (data, sections) => {


### PR DESCRIPTION
* change the 'random' function to be random when called several times in quick succession
* when an appointment is arranged that's supposed to be repeating, add 3 additional future weekly repeat appointments, booked on the same day of the week and at the same time:

![image](https://user-images.githubusercontent.com/23801/116369390-3d313200-a801-11eb-9d08-36b50540ace8.png)

## Questions

The repeat appointments aren't reflected on the 'confirmation' page – should it say anything different?