### PR TITLE
Ask if appointments are sensitive

### DIFF
--- a/app/utils/arrange-a-session-wizard-paths.js
+++ b/app/utils/arrange-a-session-wizard-paths.js
@@ -16,6 +16,7 @@ function arrangeSessionWizardPaths (req) {
     `/arrange-a-session/${CRN}/${sessionId}/rar-categories`,
     `/arrange-a-session/${CRN}/${sessionId}/add-notes`,
     `/arrange-a-session/${CRN}/${sessionId}/notes`,
+    `/arrange-a-session/${CRN}/${sessionId}/sensitive`,
     `/arrange-a-session/${CRN}/${sessionId}/check`,
     `/arrange-a-session/${CRN}/${sessionId}/confirmation`,
     `/cases/${CRN}`,
@@ -49,7 +50,7 @@ function arrangeSessionWizardForks (req) {
       currentPath: `/arrange-a-session/${CRN}/${sessionId}/add-notes`,
       storedData: ['communication', CRN, sessionId, 'add-notes'],
       values: ['No (notes can be added later)'],
-      forkPath: `/arrange-a-session/${CRN}/${sessionId}/check`
+      forkPath: `/arrange-a-session/${CRN}/${sessionId}/sensitive`
     },
     {
       currentPath: `/arrange-a-session/${CRN}/${sessionId}/rearrange-or-cancel`,

--- a/app/utils/confirm-attendance-wizard-paths.js
+++ b/app/utils/confirm-attendance-wizard-paths.js
@@ -18,6 +18,7 @@ function confirmAttendanceWizardPaths (req) {
     `${basePath}/rar-categories`,
     `${basePath}/add-notes`,
     `${basePath}/notes`,
+    `${basePath}/sensitive`,
     `${basePath}/check`,
     `${basePath}/confirmation`,
     `/arrange-a-session/${CRN}/start`,
@@ -65,7 +66,7 @@ function confirmAttendanceWizardForks (req) {
       currentPath: `${basePath}/add-notes`,
       storedData: ['communication', CRN, sessionId, 'add-notes'],
       values: ['No (notes can be added later)'],
-      forkPath: `${basePath}/check`
+      forkPath: `${basePath}/sensitive`
     }
   ]
 

--- a/app/views/arrange-a-session/_session-details.html
+++ b/app/views/arrange-a-session/_session-details.html
@@ -144,6 +144,19 @@
           }
         ]
       } if showAction or notesEditPath
-    } if not hideNotes
+    } if not hideNotes,
+    {
+      key: { text: "Sensitive" },
+      value: { text: data['communication'][CRN][sessionId]['sensitive'] },
+      actions: {
+        items: [
+          {
+            href: path + '/sensitive',
+            text: "Change",
+            visuallyHiddenText: "if this was sensitive"
+          }
+        ]
+      } if showAction
+    }
   ]
   }) }}

--- a/app/views/arrange-a-session/sensitive.html
+++ b/app/views/arrange-a-session/sensitive.html
@@ -1,0 +1,29 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'Does this appointment include sensitive information?' %}
+
+{% block form %}
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: title,
+        isPageHeading: true,
+        classes: "govuk-label--xl govuk-!-margin-bottom-6"
+      }
+    },
+    items: [
+      {
+        html: 'Yes, it includes sensitive information.<br />Some details must not be shared with ' + case.serviceUserPersonalDetails.firstName + '.',
+        value: 'Yes'
+      },
+      {
+        text: 'No, it is not sensitive',
+        value: 'No'
+      }
+    ]
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'sensitive'])) }}
+
+  {{ govukDetails({
+    summaryText: "Help with sensitive content",
+    text: ""
+  }) }}
+{% endblock %}

--- a/app/views/case/_appointment-timeline-entry.html
+++ b/app/views/case/_appointment-timeline-entry.html
@@ -15,6 +15,10 @@
   {% elseif entry['did-service-user-comply'] === 'Absent' %}
     {{ govukTag({text: 'Absent', classes: 'govuk-tag--red'}) }}
   {% endif %}
+
+  {% if entry.sensitive %}
+    {{ govukTag({ text: "Sensitive", classes: "govuk-tag--grey" }) }}
+  {% endif %}
 </h3>
 
 {% if entry['session-counts-towards-rar'] == 'Yes' %}

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -34,6 +34,10 @@
       {% elseif appointment['did-service-user-comply'] === 'Absent' %}
         {{ govukTag({text: 'Absent', classes: 'govuk-tag--red'}) }}
       {% endif %}
+
+      {% if appointment.sensitive %}
+        {{ govukTag({ text: "Sensitive", classes: "govuk-tag--grey" }) }}
+      {% endif %}
     </h1>
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-6">

--- a/app/views/confirm-attendance/_outcome-details.html
+++ b/app/views/confirm-attendance/_outcome-details.html
@@ -102,6 +102,19 @@
           }
         ]
       } if checkingAnswers
-    } if appointment['filenames'].length > 0
+    } if appointment['filenames'].length > 0,
+    {
+      key: { text: "Sensitive" },
+      value: { text: data['communication'][CRN][sessionId]['sensitive'] },
+      actions: {
+        items: [
+          {
+            href: path + '/sensitive',
+            text: "Change",
+            visuallyHiddenText: "if this was sensitive"
+          }
+        ]
+      } if showAction
+    }
   ]
   }) }}

--- a/app/views/confirm-attendance/sensitive.html
+++ b/app/views/confirm-attendance/sensitive.html
@@ -1,0 +1,29 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'Does this appointment include sensitive information?' %}
+
+{% block form %}
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: title,
+        isPageHeading: true,
+        classes: "govuk-label--xl govuk-!-margin-bottom-6"
+      }
+    },
+    items: [
+      {
+        html: 'Yes, it includes sensitive information.<br />Some details must not be shared with ' + case.serviceUserPersonalDetails.firstName + '.',
+        value: 'Yes'
+      },
+      {
+        text: 'No, it is not sensitive',
+        value: 'No'
+      }
+    ]
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'sensitive'])) }}
+
+  {{ govukDetails({
+    summaryText: "Help with sensitive content",
+    text: ""
+  }) }}
+{% endblock %}


### PR DESCRIPTION
- Ask when arranging appointment and when recording attendance
- Indicate in timeline and on appointment page if something is sensitive
- Tweak "it must not be shared with" to "some details must not be shared", as an appointment by it's nature will be shared, it's just that some aspect, probably something in the notes, is sensitive
- Show if appointment is sensitive in the check answers list

## When recording attendance or arranging
Ask this as the last question:

![Screen Shot 2021-05-11 at 09 45 09](https://user-images.githubusercontent.com/319055/117788008-e551ec80-b23e-11eb-8c93-7fd87af1ed10.png)

## Appointment page
![Screen Shot 2021-05-11 at 09 53 58](https://user-images.githubusercontent.com/319055/117788015-e6831980-b23e-11eb-881d-12b1a95a23f1.png)

## Timeline
![Screen Shot 2021-05-11 at 09 54 02](https://user-images.githubusercontent.com/319055/117788018-e71bb000-b23e-11eb-8ff5-fc84f71bfe86.png)
