### PR TITLE
Use luxon to reconstruct date from year, month and day

### DIFF
--- a/app/models/arranged-session.js
+++ b/app/models/arranged-session.js
@@ -8,26 +8,9 @@ class ArrangedSession {
   constructor (params) {
     this.params = params
 
-    this.params.date = this.getDateString(params)
+    this.params.date = DateTime.local(params.year, params.month, params.day).toISODate()
     this.params.startTime = params.startTime || '10am'
     this.params.endTime = params.endTime || '11am'
-  }
-
-  getDateString (params) {
-    if (params.date) {
-      return params.date
-    } else if (params.year) {
-      const day = this.zeroPad(params.day)
-      const month = this.zeroPad(params.month)
-      const year = params.year
-      return `${year}-${month}-${day}`
-    }
-
-    return '2021-03-25'
-  }
-
-  zeroPad (number) {
-    return ('00' + number).slice(-2)
   }
 
   get summary () {


### PR DESCRIPTION
A side-effect of this change is that the date is no longer defaulted
if some part of the date is missing.