### PR TITLE
Fix Invalid Date error when arranging appointments

### DIFF
--- a/app/models/arranged-session.js
+++ b/app/models/arranged-session.js
@@ -8,7 +8,7 @@ class ArrangedSession {
   constructor (params) {
     this.params = params
 
-    this.params.date = DateTime.local(params.year, params.month, params.day).toISODate()
+    this.params.date = DateTime.local(parseInt(params.year), parseInt(params.month), parseInt(params.day)).toISODate()
     this.params.startTime = params.startTime || '10am'
     this.params.endTime = params.endTime || '11am'
   }


### PR DESCRIPTION
This bug was introduced in #218 