### PR TITLE
Confirm attendance journey: make the 'sensitive' change link

### DIFF
--- a/app/views/confirm-attendance/_outcome-details.html
+++ b/app/views/confirm-attendance/_outcome-details.html
@@ -105,16 +105,16 @@
     } if appointment['filenames'].length > 0,
     {
       key: { text: "Sensitive" },
-      value: { text: data['communication'][CRN][sessionId]['sensitive'] },
+      value: { text: appointment['sensitive'] },
       actions: {
         items: [
           {
-            href: path + '/sensitive',
+            href: "sensitive",
             text: "Change",
             visuallyHiddenText: "if this was sensitive"
           }
         ]
-      } if showAction
+      } if checkingAnswers
     }
   ]
   }) }}


### PR DESCRIPTION
There was a bug that was preventing the change link from appearing on the 'Check' page when confirming attendance.