### PR TITLE
Capture only structured reasons for non-compliance

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -440,8 +440,7 @@ module.exports = [
         'repeating': 'No, it’s a one-off session',
         'session-counts-towards-rar': 'No',
         'did-service-user-comply': 'No',
-        'non-compliance-reason': 'Other',
-        'non-compliance-reason-other': 'Attended - Failed to Comply',
+        'non-compliance-reason': 'Attended - failed to comply',
         'confirmed': true,
         'session-notes': `I called Dylan to confirm he had understood where he needed to be and when for his induction appointment. He was rude and abusive and in general very hostile in reaction to his sentence saying this wasn’t his fault. He mentioned he “doesn’t have time for this”. I reiterated that he must be at the office on Thursday as part of his sentence requirements and if he doesn’t it’s going to reflect very poorly.`,
         'sessionId': 978
@@ -1491,7 +1490,7 @@ module.exports = [
       {
         text: 'Medium risk of harm',
         class: 'orange'
-      },     
+      },
       {
         text: 'Restraining Order',
         class: 'turquoise'
@@ -1613,8 +1612,7 @@ module.exports = [
         'session-counts-towards-rar': 'No',
         'type-of-session': 'Office visit',
         'did-service-user-comply': 'No',
-        'non-compliance-reason': 'Other',
-        'non-compliance-reason-other': 'Unacceptable Behaviour',
+        'non-compliance-reason': 'Attended - sent home (behaviour)',
         'repeating': 'No, it’s a one-off session',
         'confirmed': true,
         'session-notes': `This was a check-in appointment and Andrei mentioned that he might have to change his mobile phone number as some of his contacts are drug users and he doesn't want to jeopardise his probation. He was clearly under the influence during this appointment and did not comply.

--- a/app/models/outcomes.js
+++ b/app/models/outcomes.js
@@ -1,0 +1,19 @@
+const path = require('path')
+const contactTypes = require(path.join(__dirname, '../data/reference/contact-types.json'))
+const outcomes = require(path.join(__dirname, '../data/reference/outcomes.json'))
+
+class Outcomes {
+  static failureToComplyReasons(contactType) {
+    const outcomeCodes = contactType.outcomes
+    const outcomeDescriptions = outcomeCodes
+      .map(code => outcomes[code])
+      .filter(outcome => outcome.attended === 'Y' || outcome.attended === null)
+      .filter(outcome => outcome.compliantAcceptable === 'N')
+      .map(outcome => outcome.description)
+    return outcomeDescriptions
+  }
+}
+
+module.exports = {
+  Outcomes
+}

--- a/app/models/outcomes.js
+++ b/app/models/outcomes.js
@@ -1,16 +1,14 @@
 const path = require('path')
-const contactTypes = require(path.join(__dirname, '../data/reference/contact-types.json'))
 const outcomes = require(path.join(__dirname, '../data/reference/outcomes.json'))
 
 class Outcomes {
   static failureToComplyReasons(contactType) {
-    const outcomeCodes = contactType.outcomes
-    const outcomeDescriptions = outcomeCodes
+    return contactType
+      .outcomes
       .map(code => outcomes[code])
       .filter(outcome => outcome.attended === 'Y' || outcome.attended === null)
       .filter(outcome => outcome.compliantAcceptable === 'N')
       .map(outcome => outcome.description)
-    return outcomeDescriptions
   }
 }
 

--- a/app/views/confirm-attendance/_outcome-details.html
+++ b/app/views/confirm-attendance/_outcome-details.html
@@ -36,7 +36,7 @@
     },
     {
       key: { text: "Reason for not complying" },
-      value: { text: appointment['non-compliance-reason'] if appointment['non-compliance-reason'] !== 'Other' else appointment['non-compliance-reason-other'] },
+      value: { text: appointment['non-compliance-reason'] },
       actions: {
         items: [
           {

--- a/app/views/confirm-attendance/non-compliance-reason.html
+++ b/app/views/confirm-attendance/non-compliance-reason.html
@@ -3,35 +3,23 @@
 {% set buttonText = 'Save and continue' %}
 
 {% block form %}
-  {% set whyAcceptableHtml %}
-    {{ govukInput({
-      label: {
-        text: "Give details"
-      },
-      classes: 'govuk-!-width-two-thirds'
-    } | decorateFormAttributes(['communication', CRN, sessionId, 'non-compliance-reason-other'])) }}
-  {% endset %}
+  {% set reasons = failureToComplyReasons(data['provider-code'], appointment['type-of-session'], appointment['other-type-of-session']) | sort %}
+
+  {% set nonComplianceReasonsRadioItems = [] %}
+  {% for reason in reasons %}
+    {% set nonComplianceReasonsRadioItems = (nonComplianceReasonsRadioItems.push({
+      text: reason | capitalize
+    }), nonComplianceReasonsRadioItems) %}
+  {% endfor %}
 
   {{ govukRadios({
-       fieldset: {
-         legend: {
-           text: "How did " + case.serviceUserPersonalDetails.firstName + " not comply?",
-           classes: "govuk-label--xl",
-           isPageHeading: true
-         }
-       },
-       name: 'session-counts-towards-rar',
-       items: [
-         {
-           text: 'Behavioural issues'
-         },
-         {
-           text: 'Other',
-           conditional: {
-             html: whyAcceptableHtml
-           }
-         }
-       ]
-       } | decorateFormAttributes(['communication', CRN, sessionId, 'non-compliance-reason']))
-  }}
+      fieldset: {
+        legend: {
+          text: title,
+          classes: "govuk-label--xl",
+          isPageHeading: true
+        }
+      },
+      items: nonComplianceReasonsRadioItems
+  } | decorateFormAttributes(['communication', CRN, sessionId, 'non-compliance-reason'])) }}
 {% endblock %}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,7 @@ const path = require('path')
 const contactTypes = require(path.join(__dirname, '../app/data/reference/contact-types.json'))
 const { Locations } = require(path.join(__dirname, '../app/models/locations.js'))
 const { ArrangedSession } = require(path.join(__dirname, '../app/models/arranged-session.js'))
+const { Outcomes } = require(path.join(__dirname, '../app/models/outcomes.js'))
 const { RARCategories } = require(path.join(__dirname, '../app/models/rar-categories.js'))
 const { DateTime } = require('luxon-business-days')
 
@@ -139,6 +140,15 @@ exports.previousAppointmentsWithoutOutcomes = (CRN, data) => {
     .filter(entry => entry['did-service-user-comply'] === undefined)
 }
 
+exports.failureToComplyReasons = (providerCode, typeOfSession, contactTypeCode) => {
+  const contactType = new ArrangedSession({
+    providerCode: providerCode,
+    typeOfSession: typeOfSession,
+    contactType: contactTypeCode
+  }).contactType
+  return Outcomes.failureToComplyReasons(contactType)
+}
+
 exports.allVisibleCases = (data) => {
   return data.cases.filter(entry => !entry.hidden)
 }
@@ -183,4 +193,6 @@ exports.addHelpers = function (env) {
   env.addGlobal('userName', exports.userName)
 
   env.addGlobal('replaceDefaultUserWithSignedInUser', exports.replaceDefaultUserWithSignedInUser)
+
+  env.addGlobal('failureToComplyReasons', exports.failureToComplyReasons)
 }


### PR DESCRIPTION
The original designs for capturing reasons for non-compliance allowed free-text, which doesn't fit in with NDelius's way of recording appointment outcomes.

The new design is driven off NDelius's reference data and is an initial attempt that is technically implementable. We will collect user feedback on this design to see if we need to provider more/other options.

Before:

![image](https://user-images.githubusercontent.com/23801/118114155-2123b800-b3df-11eb-89f1-92e69d7b3324.png)

After:

![image](https://user-images.githubusercontent.com/23801/118114209-2f71d400-b3df-11eb-8edb-274d280d164d.png)
