### PR TITLE
Update confirm absence content

### DIFF
--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -27,12 +27,14 @@
        items: [
          {
            text: 'Yes',
+           value: 'Yes',
            conditional: {
              html: whyAcceptableHtml
            }
          },
          {
-           text: 'No, ' + case.serviceUserPersonalDetails.firstName + "'s absence was unacceptable"
+           text: 'No, ' + case.serviceUserPersonalDetails.firstName + "'s absence was unacceptable",
+           value: 'No'
          }
        ]
        } | decorateFormAttributes(['communication', CRN, sessionId, 'was-absence-acceptable']))

--- a/app/views/confirm-attendance/absence-acceptable.html
+++ b/app/views/confirm-attendance/absence-acceptable.html
@@ -5,7 +5,11 @@
   {% set whyAcceptableHtml %}
     {{ govukInput({
       label: {
-        text: "Why was this absence acceptable?"
+        text: "Why was Dylan absent?",
+        classes: "govuk-!-font-weight-bold"
+      },
+      hint: {
+        text: "For example, childcare, court, holiday, medical, religious, remanded in custody, stood down, work or other"
       },
       classes: 'govuk-!-width-two-thirds'
     } | decorateFormAttributes(['communication', CRN, sessionId, 'why-absence-acceptable'])) }}
@@ -28,7 +32,7 @@
            }
          },
          {
-           text: 'No'
+           text: 'No, ' + case.serviceUserPersonalDetails.firstName + "'s absence was unacceptable"
          }
        ]
        } | decorateFormAttributes(['communication', CRN, sessionId, 'was-absence-acceptable']))

--- a/app/views/confirm-attendance/compliance.html
+++ b/app/views/confirm-attendance/compliance.html
@@ -1,5 +1,5 @@
 {% extends "_wizard-form.html" %}
-{% set title = 'Did ' + case.serviceUserPersonalDetails.firstName + ' comply?' %}
+{% set title = 'Did ' + case.serviceUserPersonalDetails.firstName + ' attend and comply?' %}
 {% set buttonText = 'Save and continue' %}
 
 {% block form %}
@@ -17,11 +17,11 @@
            value: 'Yes'
          },
          {
-           text: 'No',
+           text: 'No, ' + case.serviceUserPersonalDetails.firstName + ' attended but failed to comply',
            value: 'No'
          },
          {
-           text: case.serviceUserPersonalDetails.firstName + ' was absent',
+           text: 'No, ' + case.serviceUserPersonalDetails.firstName + ' was absent',
            value: 'Absent'
          }
        ]


### PR DESCRIPTION
Research has shown users find the current compliance question unclear:
![Screenshot 2021-05-13 at 13 18 33](https://user-images.githubusercontent.com/6122118/118143613-75409380-b403-11eb-8d39-9307e15912b3.png)

We have improved the content so that choices are now more clearly explained:
![Screenshot 2021-05-13 at 15 50 06](https://user-images.githubusercontent.com/6122118/118143684-88536380-b403-11eb-95a4-de6e0730774c.png)

![Screenshot 2021-05-13 at 15 50 27](https://user-images.githubusercontent.com/6122118/118143712-8db0ae00-b403-11eb-8672-d290d12cd560.png)

And temporarily added hint text for the types of acceptable absences, which we will turn into structured options in the future:

![Screenshot 2021-05-13 at 15 48 33](https://user-images.githubusercontent.com/6122118/118143806-a4570500-b403-11eb-8f91-c5bb83f12b1c.png)
