### PR TITLE
Update sentence page layout

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -57,7 +57,7 @@ module.exports = [
     'PNC': '2012/123400000F',
     'CRN': 'J678910',
     'currentOrder': {
-      'type': 'Community Order (12 Months)',
+      'type': 'Community Order',
       'description': 'Using violence to secure entry (Criminal Law Act/CJ and Public Order Act) - 19563',
       'lengthInMonths': 12,
       'progressInMonths': 6,
@@ -69,7 +69,7 @@ module.exports = [
       'responsibleCourt': "Sheffield Magistrates' Court",
       'requirements': {
         'rar': {
-          'type': 'Rehabilitation Activity Requirement (RAR)',
+          'type': 'RAR',
           'value': '15 days',
           'lengthInDays': 15,
           'progressInDays': 5
@@ -535,7 +535,7 @@ module.exports = [
     'PNC': '2015/0292174J',
     'CRN': 'E577913',
     'currentOrder': {
-      'type': 'Suspended Sentence Order (24 Months)',
+      'type': 'Suspended Sentence Order',
       'description': 'Breach of Sexual Offences Prevention Order (Sex Offs Act 2003) [incl Breaches of Sex Offender Order (C&D Act 1998)',
       'lengthInMonths': 24,
       'progressInMonths': 17,
@@ -547,7 +547,7 @@ module.exports = [
       'responsibleCourt': 'Bradford Crown Court',
       'requirements': {
         'rar': {
-          'type': 'Rehabilitation Activity Requirement (RAR)',
+          'type': 'RAR',
           'value': '20 days',
           'lengthInDays': 20,
           'progressInDays': 18
@@ -835,7 +835,7 @@ module.exports = [
     'PNC': '2021/234511111G',
     'CRN': 'K789021',
     'currentOrder': {
-      'type': 'Suspended Sentence Order (12 Months)',
+      'type': 'Suspended Sentence Order',
       'description': 'Drive whilst disqualified (Revised 2017). Road Traffic Act 1988',
       'lengthInMonths': 12,
       'progressInMonths': 0,
@@ -847,7 +847,7 @@ module.exports = [
       'responsibleCourt': "Leeds Magistrates' Court",
       'requirements': {
         'rar': {
-          'type': 'Rehabilitation Activity Requirement (RAR)',
+          'type': 'RAR',
           'value': '20 days',
           'lengthInDays': 20,
           'progressInDays': 0
@@ -1065,7 +1065,7 @@ module.exports = [
       'responsibleCourt': "Sheffield Magistrates' Court",
       'requirements': {
         'rar': {
-          'type': 'Rehabilitation Activity Requirement (RAR)',
+          'type': 'RAR',
           'value': '15 days',
           'lengthInDays': 15,
           'progressInDays': 3
@@ -1464,7 +1464,7 @@ module.exports = [
     'PNC': '2021/156400000G',
     'CRN': 'H6785129',
     'currentOrder': {
-      'type': 'Community Order (12 Months)',
+      'type': 'Community Order',
       'description': 'Use threatening / abusive / insulting words / behaviour with intent to cause fear of / provoke unlawful violence',
       'lengthInMonths': 12,
       'progressInMonths': 1,
@@ -1476,7 +1476,7 @@ module.exports = [
       'responsibleCourt': "South Tyneside Magistrates' Court",
       'requirements': {
         'rar': {
-          'type': 'Rehabilitation Activity Requirement (RAR)',
+          'type': 'RAR',
           'value': '22 days',
           'lengthInDays': 22,
           'progressInDays': 3

--- a/app/views/case/sentence.html
+++ b/app/views/case/sentence.html
@@ -24,100 +24,69 @@
         </h2>
         <p class="govuk-body">{{ case.currentOrder.description }}</p>
 
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              View offence details
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-              <dl class="govuk-summary-list govuk-summary-list--no-border">
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    Offence date
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    {{ case.currentOrder.offenceDate | dateWithYear }}
-                  </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    Conviction date
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    {{ case.currentOrder.convictionDate | dateWithYear }}
-                  </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    Court
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    {{ case.currentOrder.court }}
-                  </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                  <dt class="govuk-summary-list__key">
-                    Responsible court
-                  </dt>
-                  <dd class="govuk-summary-list__value">
-                    {{ case.currentOrder.responsibleCourt }}
-                  </dd>
-                </div>
-                </dl>
-            </div>
-        </details>
+        {% set detailsHtml %}
+          {{ govukSummaryList({
+            classes: 'govuk-summary-list--no-border',
+            rows: [
+              {
+                key: { text: "Offence date" },
+                value: { html: case.currentOrder.offenceDate | dateWithYear }
+              },
+              {
+                key: { text: "Conviction date" },
+                value: { html: case.currentOrder.convictionDate | dateWithYear }
+              },
+              {
+                key: { text: "Court" },
+                value: { html: case.currentOrder.court }
+              },
+              {
+                key: { text: "Responsible court" },
+                value: { html: case.currentOrder.responsibleCourt }
+              }
+            ]
+          }) }}
+        {% endset %}
+
+        {{ govukDetails({
+          summaryText: "View offence details",
+          html: detailsHtml
+        }) }}
   
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
+        
         <h2 class="govuk-heading-m">
           Sentence details
         </h2>
-        <dl class="govuk-summary-list govuk-summary-list--no-border">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Sentence
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ case.currentOrder.type }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Length
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.currentOrder.lengthInMonths }} months
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Start date
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.currentOrder.startDate | dateWithYear }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            End date
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.currentOrder.endDate | dateWithYear }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Time elapsed
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.currentOrder.progressInMonths }} months elapsed (of {{ case.currentOrder.lengthInMonths }} months)
-          </dd>
-        </div>
-        </dl>
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: { text: "Sentence" },
+              value: { html: case.currentOrder.type }
+            },
+            {
+              key: { text: "Length" },
+              value: { html: case.currentOrder.lengthInMonths + ' months' }
+            },
+            {
+              key: { text: "Start date" },
+              value: { html: case.currentOrder.startDate | dateWithYear }
+            },
+            {
+              key: { text: "End date" },
+              value: { html: case.currentOrder.endDate | dateWithYear }
+            },
+            {
+              key: { text: "Time elapsed" },
+              value: { html: case.currentOrder.progressInMonths + ' months elapsed (of ' + case.currentOrder.lengthInMonths + ' months)' }
+            }
+          ]
+        }) }}
+
       </div>
 
-
+      
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <div class="govuk-!-margin-bottom-7">
@@ -137,7 +106,7 @@
           {% endfor %}
         </dl>
       </div>
-    
+
 
   </div><!--END COL TWO THIRDS-->
 

--- a/app/views/case/sentence.html
+++ b/app/views/case/sentence.html
@@ -20,11 +20,69 @@
 
       <div class="govuk-!-margin-bottom-7">
         <h2 class="govuk-heading-m">
-          {{ case.currentOrder.type }}
+          Offences
         </h2>
         <p class="govuk-body">{{ case.currentOrder.description }}</p>
+
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              View offence details
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+              <dl class="govuk-summary-list govuk-summary-list--no-border">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Offence date
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    {{ case.currentOrder.offenceDate | dateWithYear }}
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Conviction date
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    {{ case.currentOrder.convictionDate | dateWithYear }}
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Court
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    {{ case.currentOrder.court }}
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Responsible court
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    {{ case.currentOrder.responsibleCourt }}
+                  </dd>
+                </div>
+                </dl>
+            </div>
+        </details>
+  
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+        <h2 class="govuk-heading-m">
+          Sentence details
+        </h2>
         <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Sentence
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ case.currentOrder.type }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Length
           </dt>
@@ -59,6 +117,7 @@
         </dl>
       </div>
 
+
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <div class="govuk-!-margin-bottom-7">
@@ -78,48 +137,7 @@
           {% endfor %}
         </dl>
       </div>
-
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
-        <div class="govuk-!-margin-bottom-7">
-          <h3 class="govuk-heading-m">
-            Offence details
-          </h3>
-          <dl class="govuk-summary-list govuk-summary-list--no-border">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Offence date
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ case.currentOrder.offenceDate | dateWithYear }}
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Conviction date
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ case.currentOrder.convictionDate | dateWithYear }}
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Court
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ case.currentOrder.court }}
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Responsible court
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ case.currentOrder.responsibleCourt }}
-              </dd>
-            </div>
-            </dl>
-        </div>
+    
 
   </div><!--END COL TWO THIRDS-->
 


### PR DESCRIPTION
- Replaced 'Rehabilitation Activity Requirement (RAR) with 'RAR'
**Why** - RAR is a well understood term, space is limited, and the term can be further defined elsewhere in the product

- Removed length of sentence
**Why** - It's repeated in the length section and time elapsed section, so there is no need to display it in the sentence title

- Moved offence and offence details to the top of the page
**Why** - Users want to be able to see the offence first, and it provides a more logical order to offence, sentence and requirements for users

### Before

![Screenshot 2021-05-21 at 16 12 57](https://user-images.githubusercontent.com/6122118/119159731-713df280-ba4f-11eb-8cc8-fb56eb6d0a35.png)

### After 

![Screenshot 2021-05-21 at 16 12 44](https://user-images.githubusercontent.com/6122118/119159753-77cc6a00-ba4f-11eb-9b34-2a506d3708eb.png)
