### PR TITLE
Show users the dates of repeat appointments

### DIFF
--- a/app/utils/arrange-appointment-wizard-paths.js
+++ b/app/utils/arrange-appointment-wizard-paths.js
@@ -13,6 +13,7 @@ function arrangeSessionWizardPaths (req) {
     `/arrange-appointment/${CRN}/${sessionId}/where`,
     `/arrange-appointment/${CRN}/${sessionId}/when`,
     `/arrange-appointment/${CRN}/${sessionId}/repeating`,
+    `/arrange-appointment/${CRN}/${sessionId}/repeating-preview`,
     `/arrange-appointment/${CRN}/${sessionId}/rar`,
     `/arrange-appointment/${CRN}/${sessionId}/rar-categories`,
     `/arrange-appointment/${CRN}/${sessionId}/add-notes`,
@@ -40,6 +41,12 @@ function arrangeSessionWizardForks (req) {
       storedData: ['communication', CRN, sessionId, 'type-of-session'],
       excludedValues: ['Office visit', 'Other'],
       forkPath: `/arrange-appointment/${CRN}/${sessionId}/when`
+    },
+    {
+      currentPath: `/arrange-appointment/${CRN}/${sessionId}/repeating`,
+      storedData: ['communication', CRN, sessionId, 'repeating'],
+      excludedValues: ['Yes'],
+      forkPath: `/arrange-appointment/${CRN}/${sessionId}/rar`
     },
     {
       currentPath: `/arrange-appointment/${CRN}/${sessionId}/rar`,

--- a/app/views/arrange-appointment/check.html
+++ b/app/views/arrange-appointment/check.html
@@ -45,44 +45,39 @@
   <form method="post" autocomplete="off" action="{{ paths.current }}">
 
     {% if isRepeating %}
-      <h2 class="govuk-heading-l">This appointment</h2>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">This appointment</h2>
     {% endif %}
 
     {% set showAction = true %}
     {% include 'arrange-appointment/_appointment-details.html' %}
 
     {% if isRepeating %}
-      <h2 class="govuk-heading-l">Repeat appointments</h2>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">{{ appointment['repeating-count'] }} repeat appointments</h2>
+
+      {% set repeatDatesHtml %}
+        <ul class="govuk-list">
+          {% for repeatAppointmentDate in repeatAppointmentDates %}
+            <li>{{ repeatAppointmentDate | dayOfWeek }} {{ repeatAppointmentDate | dateWithYear }}</li>
+          {% endfor %}
+        </ul>
+      {% endset %}
 
       {{ govukSummaryList({
         classes: 'govuk-!-margin-bottom-9',
         rows: [
           {
-            key: { text: "Repeating" },
-            value: { text: session.summary.repeating },
+            key: { text: "Dates" },
+            value: { html: repeatDatesHtml },
             actions: {
               items: [
                 {
-                  href: arrangeSessionPath + "/when",
+                  href: arrangeSessionPath + "/repeating",
                   text: "Change",
                   visuallyHiddenText: "repeating appointment"
                 }
               ]
             }
           },
-          {
-            key: { text: "Number of repeat appointments" },
-            value: { text: session.summary.repeatingCount },
-            actions: {
-              items: [
-                {
-                  href: arrangeSessionPath + "/when",
-                  text: "Change",
-                  visuallyHiddenText: "number of repeat appointments"
-                }
-              ]
-            }
-          } if session.summary.repeatingCount,
           {
             key: { text: "RAR activity" },
             value: { text: session.summary.rarCategory if appointment['repeating-session-counts-towards-rar'] == 'yes' else 'No' },

--- a/app/views/arrange-appointment/repeating-preview.html
+++ b/app/views/arrange-appointment/repeating-preview.html
@@ -1,0 +1,40 @@
+{% extends "_wizard-form.html" %}
+{% set title = 'Appointments you’re arranging' %}
+
+{% block form %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+
+  <h2 class="govuk-heading-m">This appointment</h2>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Date</th>
+        <th class="govuk-table__header" style="width: 50%">Time</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">{{ thisAppointmentDate | dayOfWeek }} {{ thisAppointmentDate | dateWithYear }}</td>
+        <td class="govuk-table__cell">{{ appointment['session-start-time'] }} to {{ appointment['session-end-time'] }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2 class="govuk-heading-m">{{ appointment['repeating-count'] }} repeat appointments</h2>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">Date</th>
+        <th class="govuk-table__header" style="width: 50%">Time</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      {% for repeatAppointmentDate in repeatAppointmentDates %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ repeatAppointmentDate | dayOfWeek }} {{ repeatAppointmentDate | dateWithYear }}</td>
+          <td class="govuk-table__cell">{{ appointment['session-start-time'] }} to {{ appointment['session-end-time'] }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}


### PR DESCRIPTION
Show users the actual dates of repeat appointments before they confirm, so they know what appointments they are arranging.

| Page | Screenshot |
|--|--|
| Repeating? | ![Screen Shot 2021-05-25 at 10 23 53](https://user-images.githubusercontent.com/319055/119477900-47cee080-bd47-11eb-84d9-387aa5825dae.png) |
| Appointments being arranged | ![Screen Shot 2021-05-25 at 10 23 58](https://user-images.githubusercontent.com/319055/119477896-469db380-bd47-11eb-96b0-12c77928f0eb.png) |
| Check your answers | ![Screen Shot 2021-05-25 at 10 34 20](https://user-images.githubusercontent.com/319055/119477889-456c8680-bd47-11eb-8009-32bd67d0a8de.png) |

