### PR TITLE
Appointment page bug fixes and design tweaks

### DIFF
--- a/app/views/arrange-appointment/_appointment-details.html
+++ b/app/views/arrange-appointment/_appointment-details.html
@@ -134,7 +134,7 @@
     } if not hideNotes,
     {
       key: { text: "Sensitive" },
-      value: { text: appointment['sensitive'] },
+      value: { text: appointment['sensitive'] or 'No' },
       actions: {
         items: [
           {

--- a/app/views/arrange-appointment/_appointment-details.html
+++ b/app/views/arrange-appointment/_appointment-details.html
@@ -131,7 +131,7 @@
           }
         ]
       } if showAction or notesEditPath
-    } if not hideNotes,
+    } if not isOutcomeRecorded,
     {
       key: { text: "Sensitive" },
       value: { text: appointment['sensitive'] or 'No' },
@@ -144,6 +144,6 @@
           }
         ]
       } if showAction
-    }
+    } if not isOutcomeRecorded
   ]
   }) }}

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -26,7 +26,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-6">
       <span class="govuk-caption-l">{{ appointmentType | capitalize }} appointment</span>
       {{ appointment['type-of-session'] }}
 
@@ -53,7 +53,21 @@
   </div>
 </div>
 
-<h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-6">Appointment details</h3>
+{% if appointmentType === 'previous' and not isOutcomeRecorded %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="note-panel govuk-!-margin-bottom-6">
+        {{ govukWarningText({
+          html: 'Attendance not recorded<br /><a href="/confirm-attendance/' + CRN + '/' + appointment.sessionId + '">Record attendance</a>',
+          iconFallbackText: 'Warning',
+          classes: 'govuk-!-margin-bottom-0'
+        }) }}
+      </div>
+    </div>
+  </div>
+{% endif %}
+
+<h3 class="govuk-heading-l govuk-!-font-size-27">Appointment details</h3>
 
 {% set showAction = false %}
 {% set hideNotes = isOutcomeRecorded %}
@@ -66,8 +80,6 @@
 
   {% set notesEditPath = "/cases/" + CRN + "/appointments/" + sessionId + '/notes' %}
   {% include 'confirm-attendance/_outcome-details.html' %}
-{% elif appointmentType === 'previous' and not isOutcomeRecorded %}
-  {{ appWarningBanner('Attendance not recorded. <a href="/confirm-attendance/' + CRN + '/' + appointment.sessionId + '">Record attendance</a>') }}
 {% endif %}
 
 <div class="govuk-grid-row">

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -71,7 +71,6 @@
 <h3 class="govuk-heading-l govuk-!-font-size-27">Appointment details</h3>
 
 {% set showAction = false %}
-{% set hideNotes = isOutcomeRecorded %}
 {% set notesEditPath = "/cases/" + CRN + "/appointments/" + sessionId + '/notes' %}
 {% include 'arrange-appointment/_appointment-details.html' %}
 

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% set appointmentType = 'previous' if isInThePast({date: appointment['session-date'], time: appointment['session-start-time']}) else 'upcoming' %}
 {% set title = appointment['type-of-session'] + ' details' %}
+{% set isOutcomeRecorded = (not not appointment['did-service-user-comply'] ) %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
 {% block beforeContent %}
@@ -74,7 +75,6 @@
 {% set notesEditPath = "/cases/" + CRN + "/appointments/" + sessionId + '/notes' %}
 {% include 'arrange-appointment/_appointment-details.html' %}
 
-{% set isOutcomeRecorded = (not not appointment['did-service-user-comply'] ) %}
 {% if isOutcomeRecorded %}
   <h3 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-6">Outcome details</h3>
 

--- a/app/views/case/appointment.html
+++ b/app/views/case/appointment.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% set appointmentType = 'previous' if isInThePast({date: appointment['session-date'], time: appointment['session-start-time']}) else 'upcoming' %}
-{% set title = appointment['type-of-session'] + ' details' %}
+{% set title = appointment['type-of-session'] + ' with ' + replaceDefaultUserWithSignedInUser(appointment.lastUpdatedBy, data) %} %}
 {% set isOutcomeRecorded = (not not appointment['did-service-user-comply'] ) %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
@@ -29,7 +29,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-6">
       <span class="govuk-caption-l">{{ appointmentType | capitalize }} appointment</span>
-      {{ appointment['type-of-session'] }}
+      {{ title }}
 
       {% if appointment['did-service-user-comply'] or appointment.sensitive === 'Yes' or appointment['session-counts-towards-rar'] === 'Yes' %}
       <div class="govuk-!-margin-top-1">

--- a/app/views/confirm-attendance/_outcome-details.html
+++ b/app/views/confirm-attendance/_outcome-details.html
@@ -105,7 +105,7 @@
     } if appointment['filenames'].length > 0,
     {
       key: { text: "Sensitive" },
-      value: { text: appointment['sensitive'] },
+      value: { text: appointment['sensitive'] or 'No' },
       actions: {
         items: [
           {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -131,8 +131,9 @@ exports.activityLog = (CRN, data, params = {}) => {
 exports.futureAppointments = (CRN, data) => {
   return Object
     .values(data['communication'][CRN])
-    .filter(entry => entry.type === 'Appointment' )
-    .filter(entry => !exports.isInThePast({date: entry['session-date'], time: entry['session-end-time']}) )
+    .filter(entry => entry.type === 'Appointment')
+    .filter(entry => !exports.isInThePast({ date: entry['session-date'], time: entry['session-end-time'] }))
+    .sort((a, b) => a.timestamp > b.timestamp ? 1 : -1)
 }
 
 exports.nextAppointment = (CRN, data) => {


### PR DESCRIPTION
- Sort list of future appointments in the schedule
- Use warning text component for recording attendance on appointment page
- Fix bug where notes weren't being hidden when an outcome was recorded
- Hide sensitive when outcome recorded, to avoid showing twice
- Default sensitive to No if no value set
- Update page title to match activity log title

| Before | After |
|--|--|
| ![manage-supervisions herokuapp com_cases_J678910_appointments_456](https://user-images.githubusercontent.com/319055/119521680-46b3a880-bd73-11eb-8f9a-fed802c989a9.png) | ![localhost_3005_cases_J678910_appointments_456 (1)](https://user-images.githubusercontent.com/319055/119521749-5632f180-bd73-11eb-97cd-0601948e7ea6.png) |

