### PR TITLE
Quick wins

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -512,8 +512,19 @@ module.exports = [
     },
     'personalContacts': [
       {
+        'name': 'Mary Bell',
+        'relationship': 'Wife (separated)',
+        'phone': '01274 773 355',
+        'address': [
+          '21 Valley Parade',
+          'Bradford',
+          'BD8 7DY'
+        ]
+      },
+      {
         'name': 'Lewis Wilson',
         'relationship': 'Son (30 years old)',
+        'phone': '01632 960130',
         'address': [
           '57 Whatlington Road',
           'Coventry',
@@ -522,6 +533,15 @@ module.exports = [
       }
     ],
     'professionalContacts': [
+      {
+        'name': 'Fred Parker',
+        'phone': '01632 960 130',
+        'email': 'example@example.gov',
+        'provider': 'Public Protection Unit',
+        'localDeliveryUnit': 'Bradford',
+        'team': 'Sex offenders',
+        'allocatedUntilDate': '2014-04-11'
+      },
       {
         'name': 'Sian McDougall',
         'phone': '01274 496 0993',
@@ -623,8 +643,8 @@ module.exports = [
           class: 'orange'
         },
         'inCustody': {
-          text: 'High',
-          class: 'red'
+          text: 'Low',
+          class: 'green'
         }
       },
       {
@@ -634,8 +654,8 @@ module.exports = [
           class: 'red'
         },
         'inCustody': {
-          text: 'High',
-          class: 'red'
+          text: 'Low',
+          class: 'green'
         }
       },
       {
@@ -645,8 +665,8 @@ module.exports = [
           class: 'orange'
         },
         'inCustody': {
-          text: 'High',
-          class: 'red'
+          text: 'Low',
+          class: 'green'
         }
       },
       {
@@ -656,8 +676,8 @@ module.exports = [
           class: 'red'
         },
         'inCustody': {
-          text: 'High',
-          class: 'red'
+          text: 'Low',
+          class: 'green'
         }
       },
       {
@@ -667,8 +687,8 @@ module.exports = [
           class: 'orange'
         },
         'inCustody': {
-          text: 'High',
-          class: 'red'
+          text: 'Low',
+          class: 'green'
         }
       },
       {
@@ -678,8 +698,8 @@ module.exports = [
           class: 'orange'
         },
         'inCustody': {
-          text: 'High',
-          class: 'red'
+          text: 'Low',
+          class: 'green'
         }
       }
     ],

--- a/app/utils/confirm-attendance-wizard-paths.js
+++ b/app/utils/confirm-attendance-wizard-paths.js
@@ -22,9 +22,7 @@ function confirmAttendanceWizardPaths (req) {
     `${basePath}/sensitive`,
     `${basePath}/check`,
     `${basePath}/confirmation`,
-    `/arrange-appointment/${CRN}/start`,
-    `/cases/${CRN}/activity-log/add`,
-    `/confirm-attendance/${CRN}`
+    `/cases/${CRN}/activity-log`
   ]
 
   return nextAndBackPaths(paths, req)

--- a/app/views/add-other-communication/phone-call/when.html
+++ b/app/views/add-other-communication/phone-call/when.html
@@ -1,7 +1,7 @@
 {% extends "_wizard-form.html" %}
 {% set userSentEmail = communication['from'] == userName(data) %}
 {% set title = 'When did you make the phone call?' if userSentEmail else 'When was the phone call?' %}
-{% set timeLabel = 'When did the call start?' %}
+{% set timeLabel = 'What time was the call?' %}
 
 {% block form %}
   {% set otherDayHTML %}

--- a/app/views/add-other-communication/text/when.html
+++ b/app/views/add-other-communication/text/when.html
@@ -1,7 +1,7 @@
 {% extends "_wizard-form.html" %}
 {% set userSentEmail = communication['from'] == userName(data) %}
 {% set title = 'When did you send the text message?' if userSentEmail else 'When was the text message received?' %}
-{% set timeLabel = 'What time was the text message sent?' %}
+{% set timeLabel = 'What time did you send it?' if userSentEmail else 'What time was it received?' %}
 
 {% block form %}
   {% set otherDayHTML %}

--- a/app/views/arrange-appointment/confirmation.html
+++ b/app/views/arrange-appointment/confirmation.html
@@ -28,9 +28,11 @@
   }) %}
 
   {% set panelHtml %}
+  <div class="govuk-!-font-size-27">
     <strong>{{ session.summary.typeOfSession }}</strong><br />
     {{ session.summary.date | dateWithDayAndWithoutYear }} from {{ appointment['session-start-time'] | govukTime }} to {{ appointment['session-end-time'] | govukTime }}
-  {% endset %}
+ </div>
+    {% endset %}
 
   {{ govukPanel({
     titleText: title,

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -15,48 +15,80 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Overview</h1>
 
-    <h2 class="govuk-heading-m">
-      Sentence
-    </h2>
+    <div class="app-card">
+      <h2 class="govuk-heading-m">
+        Offences
+      </h2>
+      <p class="govuk-body">{{ case.currentOrder.description }}</p>
 
-    <div class="app-card govuk-!-margin-bottom-6">
-      <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-        <a href="/cases/{{ CRN }}/sentence">{{ case.currentOrder.type }}</a>
-      </h3>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      
+      <h2 class="govuk-heading-m">
+        Sentence
+      </h2>
+      <p class="govuk-body">{{ case.currentOrder.type }}</p>
 
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      <div class="govuk-!-margin-bottom-7">
+
+        <h2 class="govuk-heading-m">
+          Progress
+        </h2>
+
+        <dl class="govuk-summary-list govuk-summary-list--no-border">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Sentence
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ case.currentOrder.progressInMonths }} months elapsed (of {{ case.currentOrder.lengthInMonths }} months)
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                RAR
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ case.currentOrder.requirements.rar.progressInDays }} days completed (of {{ case.currentOrder.requirements.rar.lengthInDays }} days)
+              </dd>
+            </div>
+        </dl>
+
+          <!---
+                {% if case.currentOrder.requirements.rar %}
+                  <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
+                    Rehabilitation activity requirement
+                  </h3>
+                  <p class="govuk-!-margin-bottom-0">
+                    {{ case.currentOrder.requirements.rar.progressInDays }} days completed (of {{ case.currentOrder.requirements.rar.lengthInDays }} days)
+                  </p>
+                {% endif %}
+
+                {% if case.currentOrder.requirements.upw %}
+                  <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
+                    Unpaid work
+                  </h3>
+                  <p class="govuk-!-margin-bottom-0">
+                    {{ case.currentOrder.requirements.upw.progressInHours }} hours completed (of {{ case.currentOrder.requirements.upw.lengthInHours }} hours)
+                  </p>
+                {% endif %}
+
+                {% if case.currentOrder.requirements.ap %}
+                <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
+                  Accredited Programme
+                </h3>
+                <p class="govuk-!-margin-bottom-0">
+                  {{ case.currentOrder.requirements.ap.value }}
+                </p>
+              {% endif %}-->
+      </div>
       <p>
-        {{ case.currentOrder.progressInMonths }} months elapsed (of {{ case.currentOrder.lengthInMonths }} months)
+        <a href="/cases/{{ CRN }}/sentence">View sentence</a>
       </p>
-
-      {% if case.currentOrder.requirements.rar %}
-        <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-          Rehabilitation activity requirement
-        </h3>
-        <p class="govuk-!-margin-bottom-0">
-          {{ case.currentOrder.requirements.rar.progressInDays }} days completed (of {{ case.currentOrder.requirements.rar.lengthInDays }} days)
-        </p>
-      {% endif %}
-
-      {% if case.currentOrder.requirements.upw %}
-        <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-          Unpaid work
-        </h3>
-        <p class="govuk-!-margin-bottom-0">
-          {{ case.currentOrder.requirements.upw.progressInHours }} hours completed (of {{ case.currentOrder.requirements.upw.lengthInHours }} hours)
-        </p>
-      {% endif %}
-
-      {% if case.currentOrder.requirements.ap %}
-      <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-        Accredited Programme
-      </h3>
-      <p class="govuk-!-margin-bottom-0">
-        {{ case.currentOrder.requirements.ap.value }}
-      </p>
-    {% endif %}
     </div>
+    <br><br>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <h2 class="govuk-heading-m">
       Risks
     </h2>
@@ -115,87 +147,72 @@
     <h2 class="govuk-heading-m">
       Contact details
     </h2>
-
-    <dl class="app-card__one-third-column-list">
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Address
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.address.join('<br>') | safe }}
-        </dd>
-      </div>
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Phone number
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.phone }}
-        </dd>
-      </div>
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Email
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.email }}
-        </dd>
-      </div>
-    </dl>
+    {{ govukSummaryList({
+      classes: 'govuk-summary-list--no-border',
+      rows: [
+        {
+          key: { text: "Address" },
+          value: { html: case.serviceUserPersonalDetails.address.join('<br>') }
+        },
+        {
+          key: { text: "Phone number" },
+          value: { text: case.serviceUserPersonalDetails.phone }
+        },
+        {
+          key: { text: "Email" },
+          value: { text: case.serviceUserPersonalDetails.email }
+        }
+      ]
+    }) }}
 
     {% if case.personalContacts.length > 0 %}
     <p class="govuk-body">
-      <a class="govuk-heading-s" href="/cases/{{ CRN }}/address-book-personal">View all personal contacts ({{ case.personalContacts.length }})</a>
+      <a href="/cases/{{ CRN }}/address-book-personal">View all personal contacts ({{ case.personalContacts.length }})</a>
     </p>
   {% endif %}
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <h2 class="govuk-heading-m">
-      Personal details and circumstances
-    </h2>
 
-    <dl class="app-card__one-third-column-list">
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Preferred language
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.preferredLanguage }}
-        </dd>
-      </div>
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Disabilities and adjustments
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') | default('<span class="govuk-hint-s">None known</span>', true) | safe }}
-        </dd>
-      </div>
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Employment status
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.circumstances.employment }}
-        </dd>
-      </div>
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Housing status
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.circumstances.housingStatus }}
-        </dd>
-      </div>
-      <div class="app-card__one-third-column-list-item">
-        <dt class="app-card__one-third-column-list-key">
-          Safeguarding issues
-        </dt>
-        <dd class="app-card__one-third-column-list-value">
-          {{ case.serviceUserPersonalDetails.circumstances.safeguardingIssues.join(', ') or 'None' }}
-        </dd>
-      </div>
-    </dl>
+    <h2 class="govuk-heading-m">
+      Personal details
+    </h2>
+    {{ govukSummaryList({
+      classes: 'govuk-summary-list--no-border',
+      rows: [
+        {
+          key: { text: "Preferred language" },
+          value: { text: case.serviceUserPersonalDetails.preferredLanguage }
+        },
+        {
+          key: { text: "Disabilities and adjustments" },
+          value: { text: case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') | default('<span class="govuk-hint-s">None known</span>', true) | safe }
+        }
+      ]
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+      <h2 class="govuk-heading-m">
+        Circumstances
+      </h2>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: { text: "Employment status" },
+            value: { text: case.serviceUserPersonalDetails.circumstances.employment }
+          },
+          {
+            key: { text: "Housing status" },
+            value: { text: case.serviceUserPersonalDetails.circumstances.housingStatus }
+          },
+          {
+            key: { text: "Safeguarding issues" },
+            value: { text: case.serviceUserPersonalDetails.circumstances.safeguardingIssues.join(', ') or 'None' }
+          }
+        ]
+        }) }}
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <h2 class="govuk-heading-m">
@@ -235,31 +252,17 @@
 
   <div class="govuk-grid-column-one-third">
 
-    <!--TIME ARRANGED-->
-    <h2 class="govuk-heading-m">
-      Actions
-    </h2>
-    <p class="govuk-body">
-      <a href="/arrange-appointment/{{ CRN }}/start" class="govuk-button govuk-!-margin-bottom-0">
-        Arrange an appointment
-      </a>
-    </p>
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-6">
-      Next appointment
-    </h2>
     {% set nextApp = nextAppointment(CRN, data) %}
     <div class="app-card app-card--blue govuk-!-margin-bottom-3">
+      <strong>
+        The next appointment is
+      </strong><br>
       {% if nextApp %}
-        {{ nextApp['type-of-session'] }}<br>
         <strong>
-          {{ nextApp['session-date'] | dateWithDayAndWithoutYear }} from<br>
-          {{ nextApp['session-start-time'] | govukTime }} to {{ nextApp['session-end-time'] | govukTime }}
-        </strong>
-        <a href="/arrange-appointment/{{ CRN }}/{{ nextApp.sessionId }}/rearrange-or-cancel" class="govuk-button govuk-button--secondary govuk-!-margin-top-4 govuk-!-margin-bottom-0"
-          data-module="govuk-button">
-          Rearrange or cancel appointment
-        </a>
+          {{ nextApp['session-date'] | dateWithDayAndWithoutYear }} at
+          {{ nextApp['session-start-time'] | govukTime }}
+        </strong><br>
+        <strong>{{ nextApp['type-of-session'] }}</strong>
       {% else %}
         <strong>No appointments scheduled</strong>
       {% endif %}

--- a/app/views/confirm-attendance/confirmation.html
+++ b/app/views/confirm-attendance/confirmation.html
@@ -1,22 +1,19 @@
 {% extends "_wizard-page.html" %}
-{% set buttonText = 'Arrange an appointment' %}
+{% set buttonText = 'Finish' %}
 {% set title = "Attendance recorded" %}
 
 {% block page %}
 
   {% set panelHtml %}
+  <div class="govuk-!-font-size-27">
     <strong>{{ appointment['type-of-session'] }}</strong><br>
     {{ appointment['session-date'] | dateWithDayAndWithoutYear }} from {{ appointment['session-start-time'] }} to {{ appointment['session-end-time'] }}
-  {% endset %}
+  </div>
+    {% endset %}
 
   {{ govukPanel({
     titleText: title,
     html: panelHtml
   }) }}
 
-  <h2 class="govuk-heading-m">Next steps</h2>
-
-    <div style="margin-top: 20px;">
-      <a class="govuk-body" href="/cases/{{ case.CRN }}/activity-log">Back to {{ case.serviceUserPersonalDetails.firstName }}’s communication</a>
-    </div>
 {% endblock %}


### PR DESCRIPTION
- Add offence details to overview
- Make overview lists consistent with sentence and details pages
- Remove arrange appoint CTA as it's now in the schedule
- Remove rearrange appointment CTA - can do from appointment detail page
- Cleaned up the confirmation page after confirming attendance – remove CTA to arrange another appointment
- Changed wording of phone call and text journey
- Make Brian lower risk, adding contacts

Authored by @kelliedesigner 