### PR TITLE
Add initial pages for risk flags

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -101,3 +101,8 @@ $govuk-assets-path: '/govuk/assets/';
   border: 1px solid $govuk-border-colour;
   padding: govuk-spacing(3);
 }
+
+.app-flags-table-cell {
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,5 +1,6 @@
 // global styles for <a> and <p> tags
 $govuk-global-styles: true;
+$govuk-new-link-styles: true;
 
 // We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
 $govuk-assets-path: '/govuk/assets/';
@@ -36,6 +37,21 @@ $govuk-assets-path: '/govuk/assets/';
 // Document icon image
 .moj-timeline__document-link {
   background-image: url(/public/images/icon-document.svg) !important;
+}
+
+.govuk-tag--link {
+  padding: 0
+}
+
+.govuk-tag--link a {
+  line-height: 1.5em;
+  color: inherit;
+  padding: 6px 10px;
+  display: inline-block;
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
 }
 
 // Secondary text colour

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -136,11 +136,16 @@ module.exports = [
     'riskBadges': [
       {
         text: 'Medium risk of harm',
-        class: 'orange'
+        class: 'orange',
+        rosh: true
       },
       {
         text: 'IOM',
-        class: 'blue'
+        class: 'grey',
+        notes: 'Cross-agency',
+        reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+        dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+        mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
     'riskOfSeriousHarmLevel': {
@@ -620,19 +625,31 @@ module.exports = [
     'riskBadges': [
       {
         text: 'High risk of harm',
-        class: 'red'
+        class: 'red',
+        rosh: true
       },
       {
-        text: 'Registered Sex Offender',
-        class: 'purple'
+        text: 'Registered sex offender',
+        class: 'purple',
+        notes: 'Possession of indecent images',
+        reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+        dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+        mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       },
       {
         text: 'MAPPA',
-        class: 'purple'
+        class: 'purple',
+        notes: 'Level 2, Category 3',
+        reviewDue: helpers.happenedOn({ daysAgo: '1' }),
+        dateAdded: helpers.happenedOn({ daysAgo: '91' })
       },
       {
         text: 'Restraining order',
-        class: 'turquoise'
+        class: 'turquoise',
+        notes: 'Against ex-partner',
+        reviewDue: helpers.happeningIn({ daysLater: 60, atTime: '13:00' }),
+        dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+        mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
     'riskOfSeriousHarmLevel': {
@@ -914,7 +931,8 @@ module.exports = [
     'riskBadges': [
       {
         text: 'Medium risk of harm',
-        class: 'orange'
+        class: 'orange',
+        rosh: true
       }
     ],
     'riskOfSeriousHarmLevel': {
@@ -1136,11 +1154,16 @@ module.exports = [
     'riskBadges': [
       {
         text: 'Medium risk of harm',
-        class: 'orange'
+        class: 'orange',
+        rosh: true
       },
       {
         text: 'Domestic abuse',
-        class: 'turquoise'
+        class: 'turquoise',
+        notes: 'Partner is the victim',
+        reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+        dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+        mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
     'riskOfSeriousHarmLevel': {
@@ -1549,11 +1572,16 @@ module.exports = [
     'riskBadges': [
       {
         text: 'Medium risk of harm',
-        class: 'orange'
+        class: 'orange',
+        rosh: true
       },
       {
         text: 'Restraining Order',
-        class: 'turquoise'
+        class: 'turquoise',
+        notes: 'Against ex-partner',
+        reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+        dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+        mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
     'riskOfSeriousHarmLevel': {

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -623,12 +623,16 @@ module.exports = [
         class: 'red'
       },
       {
-        text: 'Sex Offender',
+        text: 'Registered Sex Offender',
         class: 'purple'
       },
       {
         text: 'MAPPA',
         class: 'purple'
+      },
+      {
+        text: 'Restraining order',
+        class: 'turquoise'
       }
     ],
     'riskOfSeriousHarmLevel': {

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,4 +1,5 @@
 const { DateTime } = require('luxon')
+const slugify = require('slugify')
 
 module.exports = function (env) {
   /**
@@ -8,6 +9,11 @@ module.exports = function (env) {
    * @type {Object}
    */
   var filters = {}
+
+  // example: Monday
+  filters.toSlug = string => {
+    return slugify(string, { lower: true })
+  }
 
   // example: Monday 7 December
   filters.dateWithDayAndWithoutYear = datetimeString => {

--- a/app/filters.js
+++ b/app/filters.js
@@ -10,7 +10,7 @@ module.exports = function (env) {
    */
   var filters = {}
 
-  // example: Monday
+  // example: "This thing" becomes "this-thing"
   filters.toSlug = string => {
     return slugify(string, { lower: true })
   }

--- a/app/routes/cases.js
+++ b/app/routes/cases.js
@@ -2,6 +2,7 @@ const {
   generateRandomString,
   getDataValue
 } = require('../utils/helpers')
+const slugify = require('slugify')
 
 module.exports = router => {
   router.get([
@@ -82,6 +83,15 @@ module.exports = router => {
   router.all('/cases/:CRN/other-communication/:sessionId', function (req, res) {
     res.locals.sessionId = req.params.sessionId
     res.render('case/other-communication')
+  })
+
+  router.all('/cases/:CRN/flag/:flagSlug', function (req, res) {
+    const riskBadges = res.locals.case.riskBadges
+    const flag = riskBadges.find(flag => {
+      return slugify(flag.text, { lower: true }) === req.params.flagSlug
+    })
+    res.locals.flag = flag
+    res.render('case/flag')
   })
 
   router.all('/cases/:CRN/:view', function (req, res) {

--- a/app/views/case/_case-nav.html
+++ b/app/views/case/_case-nav.html
@@ -37,6 +37,13 @@
             {% endif %}
             href="/cases/{{ CRN }}/sentence">Sentence</a>
         </li>
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'flags' %}
+            aria-current="page"
+            {% endif %}
+            href="/cases/{{ CRN }}/flags">Risk flags</a>
+        </li>
       </ul>
     </nav>
   </div>

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -8,9 +8,13 @@
 
 <p>
   {% for badge in case.riskBadges %}
-    {{ govukTag({ html: '<a href="#">' + badge.text + '</a>', classes: 'govuk-tag--link govuk-!-margin-right-1 govuk-tag--' + badge.class }) }}
-    <!-- <span class="govuk-tag govuk-tag--{{ badge.class }}{{ ' govuk-!-margin-right-2' }}">
-      {{ badge.text }}
-    </span> -->
+    {% set badgeHtml %}
+      {% if badge.rosh %}
+        <a href="#">{{ badge.text }}</a>
+      {% else %}
+        <a href="/cases/{{ CRN }}/flag/{{ badge.text | toSlug }}">{{ badge.text }}</a>
+      {% endif %}
+    {% endset %}
+    {{ govukTag({ html: badgeHtml, classes: 'govuk-tag--link govuk-!-margin-right-1 govuk-tag--' + badge.class }) }}
   {% endfor %}
 </p>

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -8,8 +8,9 @@
 
 <p>
   {% for badge in case.riskBadges %}
-    <span class="govuk-tag govuk-tag--{{ badge.class }}{{ ' govuk-!-margin-right-2' }}">
+    {{ govukTag({ html: '<a href="#">' + badge.text + '</a>', classes: 'govuk-tag--link govuk-!-margin-right-1 govuk-tag--' + badge.class }) }}
+    <!-- <span class="govuk-tag govuk-tag--{{ badge.class }}{{ ' govuk-!-margin-right-2' }}">
       {{ badge.text }}
-    </span>
+    </span> -->
   {% endfor %}
 </p>

--- a/app/views/case/flag.html
+++ b/app/views/case/flag.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% set title = 'Registered sex offender' %}
+{% set title = flag.text %}
 {% block pageTitle %}{{ title }}{% endblock %}
 
 {% block beforeContent %}
@@ -31,7 +31,7 @@
         text: "Next review"
       },
       value: {
-        text: "10 November 2021"
+        text: flag.reviewDue | dateWithYear
       },
       actions: {
         items: [
@@ -48,7 +48,7 @@
         text: "Added"
       },
       value: {
-        text: "10 November 2020 by Mark Berridge"
+        text: flag.dateAdded | dateWithYear + " by Mark Berridge"
       }
     },
     {
@@ -56,7 +56,7 @@
         text: "Most recent review"
       },
       value: {
-        text: "22 March 2021 by Mark Berridge"
+        text: flag.mostRecentReviewDate | dateWithYear + " by Mark Berridge" if flag.mostRecentReviewDate else 'Not reviewed yet'
       },
       actions: {
         items: [
@@ -65,14 +65,14 @@
             text: "View review"
           }
         ]
-      }
+      } if flag.mostRecentReviewDate
     },
     {
       key: {
         text: "Notes"
       },
       value: {
-        text: "Possession of indecent images"
+        text: flag.notes
       },
       actions: {
         items: [

--- a/app/views/case/flag.html
+++ b/app/views/case/flag.html
@@ -1,0 +1,79 @@
+{% extends "layout.html" %}
+{% set title = 'Registered sex offender' %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back to risk flags",
+    href: "/cases/" + CRN + "/flags"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">
+      <span class="govuk-caption-xl">Risk flag</span>
+      {{ title }}
+    </h1>
+  </div>
+</div>
+
+    <!-- {{ govukButton({
+      text: 'Review or amend flag',
+      href: '#'
+    }) }} -->
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "Description"
+          },
+          value: {
+            text: "Possession of indecent images"
+          },
+          actions: {
+            items: [
+              {
+                href: "#",
+                text: "Change",
+                visuallyHiddenText: "name"
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: "Next review"
+          },
+          value: {
+            text: "10 November 2021"
+          }
+        },
+        {
+          key: {
+            text: "Added by"
+          },
+          value: {
+            text: "Mark Berridge on 10 November 2020"
+          }
+        },
+        {
+          key: {
+            text: "Last review by"
+          },
+          value: {
+            text: "Mark Berridge on 22 March 2021"
+          }
+        }
+      ]
+    }) }}
+
+    <p>
+      <a href="#">Remove flag</a>
+    </p>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/case/flag.html
+++ b/app/views/case/flag.html
@@ -19,61 +19,114 @@
   </div>
 </div>
 
-    <!-- {{ govukButton({
-      text: 'Review or amend flag',
-      href: '#'
-    }) }} -->
+<!-- {{ govukButton({
+  text: 'Review or amend flag',
+  href: '#'
+}) }} -->
 
-    {{ govukSummaryList({
-      rows: [
-        {
-          key: {
-            text: "Description"
-          },
-          value: {
-            text: "Possession of indecent images"
-          },
-          actions: {
-            items: [
-              {
-                href: "#",
-                text: "Change",
-                visuallyHiddenText: "name"
-              }
-            ]
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        text: "Next review"
+      },
+      value: {
+        text: "10 November 2021"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Review",
+            visuallyHiddenText: "flag"
           }
-        },
-        {
-          key: {
-            text: "Next review"
-          },
-          value: {
-            text: "10 November 2021"
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Added"
+      },
+      value: {
+        text: "10 November 2020 by Mark Berridge"
+      }
+    },
+    {
+      key: {
+        text: "Most recent review"
+      },
+      value: {
+        text: "22 March 2021 by Mark Berridge"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "View review"
           }
-        },
-        {
-          key: {
-            text: "Added by"
-          },
-          value: {
-            text: "Mark Berridge on 10 November 2020"
+        ]
+      }
+    },
+    {
+      key: {
+        text: "Notes"
+      },
+      value: {
+        text: "Possession of indecent images"
+      },
+      actions: {
+        items: [
+          {
+            href: "#",
+            text: "Change",
+            visuallyHiddenText: "notes"
           }
-        },
-        {
-          key: {
-            text: "Last review by"
-          },
-          value: {
-            text: "Mark Berridge on 22 March 2021"
-          }
-        }
-      ]
-    }) }}
+        ]
+      }
+    }
+  ]
+}) }}
 
-    <p>
-      <a href="#">Remove flag</a>
-    </p>
+<p class="govuk-!-margin-bottom-7">
+  <a href="#">Remove flag</a>
+</p>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Guidance using this flag</h2>
+    <h3 class="govuk-heading-m">Purpose of use</h3>
+
+    <p>To identify offenders convicted under the Sexual Offences Act 2003 and therefore subject to the notification period and requirements of the Sex Offender Register.</p>
+
+    <h3 class="govuk-heading-m">Category</h3>
+
+    <p>{{ govukTag({ text: 'Public protection', classes: 'govuk-tag--purple' }) }}</p>
+    <p><a href="#">About this category</a></p>
+
+    <h3 class="govuk-heading-m">Suggested review frequency</h3>
+
+    <p>Every 3 months</p>
+
+    <h3 class="govuk-heading-m">Termination</h3>
+
+    <p>Remove at termination, except for life sentences.</p>
+
+    <h3 class="govuk-heading-m">Further information</h3>
+
+    <p>Notification Periods for offenders sentenced under the Sexual Offences Act 2003:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Imprisonment for a fixed period of 30 months or more, Imprisonment for an indefinite period, imprisonment for public protection, or admission to hospital under restriction order, or subject to an Order for Lifelong Restriction: Indefinitely </li>
+      <li>Imprisonment for more than 6 months but less than 30 months: 10 years</li>
+      <li>Imprisonment for 6 months or less, or admission to hospital without restriction order: 7 years</li>
+      <li>Caution: 2 years</li>
+      <li>Conditional discharge or (in Scotland) a probation order: Period of discharge or probation</li>
+      <li>Any other: 5 years</li>
+      <li>Finite notification periods are halved if the person is under 18 when convicted or cautioned.</li>
+    </ul>
+
+    <p>If an offender is on the register for an indefinite period they can apply to the police area managing them to come off the register 15 years from their initial notification (if made upon release from prison) or first registration upon release from custody (in case they registered upon conviction).</p>
+
+    <p>(Also extended licences will impact on this as well and will render people to be placed on the register indefinitely – stated case is R v Wiles.)
   </div>
 </div>
-
 {% endblock %}

--- a/app/views/case/flags.html
+++ b/app/views/case/flags.html
@@ -70,25 +70,25 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" style="width: 30%">Flag</th>
-      <th class="govuk-table__header" style="width: 55%">Description</th>
+      <th class="govuk-table__header" style="width: 55%">Notes</th>
       <th class="govuk-table__header" style="width: 15%">Review due</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="/cases/' + CRN + '/flag">Registered sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
-      <td class="govuk-table__cell">Possession of indecent images</td>
-      <td class="govuk-table__cell">5 days</td>
+      <td class="govuk-table__cell app-flags-table-cell">Possession of indecent images</td>
+      <td class="govuk-table__cell app-flags-table-cell">5 days</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">MAPPA</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
-      <td class="govuk-table__cell">Level 2, Category 3</td>
-      <td class="govuk-table__cell"><a href="#">Needs review</a></td>
+      <td class="govuk-table__cell app-flags-table-cell">Level 2, Category 3</td>
+      <td class="govuk-table__cell app-flags-table-cell"><a href="#">Needs review</a></td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Restraining order</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
-      <td class="govuk-table__cell">Against ex-partner</td>
-      <td class="govuk-table__cell">10 Nov 2020</td>
+      <td class="govuk-table__cell app-flags-table-cell">Against ex-partner</td>
+      <td class="govuk-table__cell app-flags-table-cell">10 Nov 2020</td>
     </tr>
   </tbody>
 </table>
@@ -98,35 +98,35 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" style="width: 30%">Flag</th>
-      <th class="govuk-table__header" style="width: 55%">Description</th>
+      <th class="govuk-table__header" style="width: 55%">Notes</th>
       <th class="govuk-table__header" style="width: 20%">Date removed</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Weapons</a>', classes: 'govuk-tag--link govuk-tag--pink' }) }}</td>
-      <td class="govuk-table__cell">Caught carrying a knife</td>
-      <td class="govuk-table__cell">Today</td>
+      <td class="govuk-table__cell app-flags-table-cell">Caught carrying a knife</td>
+      <td class="govuk-table__cell app-flags-table-cell">Today</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Domestic abuse</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
-      <td class="govuk-table__cell">Possession of indecent images</td>
-      <td class="govuk-table__cell">Today</td>
+      <td class="govuk-table__cell app-flags-table-cell">Possession of indecent images</td>
+      <td class="govuk-table__cell app-flags-table-cell">Today</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Victim</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
-      <td class="govuk-table__cell">Level 2, Category 3</td>
-      <td class="govuk-table__cell">2 Jan 2021</td>
+      <td class="govuk-table__cell app-flags-table-cell">Level 2, Category 3</td>
+      <td class="govuk-table__cell app-flags-table-cell">2 Jan 2021</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Vulnerable</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
-      <td class="govuk-table__cell">Level 2, Category 3</td>
-      <td class="govuk-table__cell">10 Nov 2020</td>
+      <td class="govuk-table__cell app-flags-table-cell">Level 2, Category 3</td>
+      <td class="govuk-table__cell app-flags-table-cell">10 Nov 2020</td>
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">IOM</a>', classes: 'govuk-tag--link govuk-tag--grey' }) }}</td>
-      <td class="govuk-table__cell">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</td>
-      <td class="govuk-table__cell">10 Nov 2020</td>
+      <td class="govuk-table__cell app-flags-table-cell">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</td>
+      <td class="govuk-table__cell app-flags-table-cell">10 Nov 2020</td>
     </tr>
   </tbody>
 </table>

--- a/app/views/case/flags.html
+++ b/app/views/case/flags.html
@@ -63,8 +63,6 @@
   html: categoryHtml
 }) }}
 
-
-
 <h2 class="govuk-heading-m">Current flags</h2>
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -75,21 +73,18 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="/cases/' + CRN + '/flag">Registered sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
-      <td class="govuk-table__cell app-flags-table-cell">Possession of indecent images</td>
-      <td class="govuk-table__cell app-flags-table-cell">5 days</td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">MAPPA</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
-      <td class="govuk-table__cell app-flags-table-cell">Level 2, Category 3</td>
-      <td class="govuk-table__cell app-flags-table-cell"><a href="#">Needs review</a></td>
-    </tr>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Restraining order</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
-      <td class="govuk-table__cell app-flags-table-cell">Against ex-partner</td>
-      <td class="govuk-table__cell app-flags-table-cell">10 Nov 2020</td>
-    </tr>
+    {% for flag in case.riskBadges %}
+      {% if not flag.rosh %}
+        {% set tagHtml %}
+          <a href="/cases/{{ CRN }}/flag/{{ flag.text | toSlug }}">{{ flag.text }}</a>
+        {% endset %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ govukTag({ html: tagHtml, classes: 'govuk-tag--link govuk-tag--' + flag.class }) }}</td>
+          <td class="govuk-table__cell app-flags-table-cell">{{ flag.notes }}</td>
+          <td class="govuk-table__cell app-flags-table-cell">{{ flag.reviewDue | dateWithYear }}</td>
+        </tr>
+      {% endif %}
+    {% endfor %}
   </tbody>
 </table>
 
@@ -110,7 +105,7 @@
     </tr>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Domestic abuse</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
-      <td class="govuk-table__cell app-flags-table-cell">Possession of indecent images</td>
+      <td class="govuk-table__cell app-flags-table-cell">Against ex-partner</td>
       <td class="govuk-table__cell app-flags-table-cell">Today</td>
     </tr>
     <tr class="govuk-table__row">

--- a/app/views/case/flags.html
+++ b/app/views/case/flags.html
@@ -1,0 +1,133 @@
+{% extends "layout.html" %}
+{% set title = 'Risk flags' %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block content %}
+
+{% include "case/_case-service-user-banner.html" %}
+
+{% set currentNavSection = 'flags' %}
+{% include "case/_case-nav.html" %}
+
+<!-- Alerts, Safeguarding, Public protection, Information -->
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ title }}</h1>
+  </div>
+</div>
+
+{% set categoryHtml %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{{ govukSummaryList({
+  rows: [
+    {
+      key: {
+        html: govukTag({ text: 'Alerts', classes: 'govuk-tag--pink' })
+      },
+      value: {
+        text: "Description of alerts, for example Weapons or Serious group offending"
+      }
+    },
+    {
+      key: {
+        html: govukTag({ text: 'Safeguarding', classes: 'govuk-tag--turquoise' })
+      },
+      value: {
+        text: "Description of safeguarding, for example Victim or Vulnerable"
+      }
+    },
+    {
+      key: {
+        html: govukTag({ text: 'Public protection', classes: 'govuk-tag--purple' })
+      },
+      value: {
+        text: "Description of public protection, for example Domestic abuse"
+      }
+    },
+    {
+      key: {
+        html: govukTag({ text: 'Information', classes: 'govuk-tag--grey' })
+      },
+      value: {
+        text: "Description of information, for example Integrated Offender Management (IOM)"
+      }
+    }
+  ]
+}) }}
+{% endset %}
+
+{{ govukDetails({
+  summaryText: "Risk flag categories",
+  html: categoryHtml
+}) }}
+
+
+
+<h2 class="govuk-heading-m">Current flags</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" style="width: 30%">Flag</th>
+      <th class="govuk-table__header" style="width: 55%">Description</th>
+      <th class="govuk-table__header" style="width: 15%">Review due</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="/cases/' + CRN + '/flag">Registered sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
+      <td class="govuk-table__cell">Possession of indecent images</td>
+      <td class="govuk-table__cell">5 days</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">MAPPA</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
+      <td class="govuk-table__cell">Level 2, Category 3</td>
+      <td class="govuk-table__cell"><a href="#">Needs review</a></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Restraining order</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
+      <td class="govuk-table__cell">Against ex-partner</td>
+      <td class="govuk-table__cell">10 Nov 2020</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 class="govuk-heading-m">Historic flags</h2>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" style="width: 30%">Flag</th>
+      <th class="govuk-table__header" style="width: 55%">Description</th>
+      <th class="govuk-table__header" style="width: 20%">Date removed</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Weapons</a>', classes: 'govuk-tag--link govuk-tag--pink' }) }}</td>
+      <td class="govuk-table__cell">Caught carrying a knife</td>
+      <td class="govuk-table__cell">Today</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Domestic abuse</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
+      <td class="govuk-table__cell">Possession of indecent images</td>
+      <td class="govuk-table__cell">Today</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Victim</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
+      <td class="govuk-table__cell">Level 2, Category 3</td>
+      <td class="govuk-table__cell">2 Jan 2021</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Vulnerable</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
+      <td class="govuk-table__cell">Level 2, Category 3</td>
+      <td class="govuk-table__cell">10 Nov 2020</td>
+    </tr>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">IOM</a>', classes: 'govuk-tag--link govuk-tag--grey' }) }}</td>
+      <td class="govuk-table__cell">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</td>
+      <td class="govuk-table__cell">10 Nov 2020</td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -63,7 +63,7 @@
       rows: [
         {
           key: {
-            html: govukTag({ html: '<a href="#">Sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' })
+            html: govukTag({ html: '<a href="#">Registered sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' })
           },
           value: {
             html: '

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -15,79 +15,86 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Overview</h1>
 
-    <div class="app-card">
-      <h2 class="govuk-heading-m">
-        Offences
-      </h2>
-      <p class="govuk-body">{{ case.currentOrder.description }}</p>
+    <h2 class="govuk-heading-m">
+      Offences
+    </h2>
+    <p class="govuk-body">{{ case.currentOrder.description }}</p>
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-      
-      <h2 class="govuk-heading-m">
-        Sentence
-      </h2>
-      <p class="govuk-body">{{ case.currentOrder.type }}</p>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <h2 class="govuk-heading-m">
+      Sentence
+    </h2>
+    <p class="govuk-body">{{ case.currentOrder.type }}</p>
 
-      <div class="govuk-!-margin-bottom-7">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <h2 class="govuk-heading-m">
+      Progress
+    </h2>
 
-        <h2 class="govuk-heading-m">
-          Progress
-        </h2>
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Sentence
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ case.currentOrder.progressInMonths }} months elapsed (of {{ case.currentOrder.lengthInMonths }} months)
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            RAR
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ case.currentOrder.requirements.rar.progressInDays }} days completed (of {{ case.currentOrder.requirements.rar.lengthInDays }} days)
+          </dd>
+        </div>
+    </dl>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-        <dl class="govuk-summary-list govuk-summary-list--no-border">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Sentence
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ case.currentOrder.progressInMonths }} months elapsed (of {{ case.currentOrder.lengthInMonths }} months)
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                RAR
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ case.currentOrder.requirements.rar.progressInDays }} days completed (of {{ case.currentOrder.requirements.rar.lengthInDays }} days)
-              </dd>
-            </div>
-        </dl>
+    <h2 class="govuk-heading-m">
+      Risk flags
+    </h2>
 
-          <!---
-                {% if case.currentOrder.requirements.rar %}
-                  <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-                    Rehabilitation activity requirement
-                  </h3>
-                  <p class="govuk-!-margin-bottom-0">
-                    {{ case.currentOrder.requirements.rar.progressInDays }} days completed (of {{ case.currentOrder.requirements.rar.lengthInDays }} days)
-                  </p>
-                {% endif %}
+    <p><a href="#">Add, review or remove flags</a></p>
 
-                {% if case.currentOrder.requirements.upw %}
-                  <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-                    Unpaid work
-                  </h3>
-                  <p class="govuk-!-margin-bottom-0">
-                    {{ case.currentOrder.requirements.upw.progressInHours }} hours completed (of {{ case.currentOrder.requirements.upw.lengthInHours }} hours)
-                  </p>
-                {% endif %}
+    {{ govukSummaryList({
+      classes: 'govuk-summary-list--no-border',
+      rows: [
+        {
+          key: {
+            html: govukTag({ html: '<a href="#">Sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' })
+          },
+          value: {
+            html: '
+              <p>Possession of indecent images</p>
+            '
+          }
+        },
+        {
+          key: {
+            html: govukTag({ html: '<a href="#">MAPPA</a>', classes: 'govuk-tag--link govuk-tag--purple' })
+          },
+          value: {
+            html: '
+              <p class="govuk-!-margin-bottom-1">Level 2, Category 3</p>
+            '
+          }
+        },
+        {
+          key: {
+            html: govukTag({ html: '<a href="#">Restraining order</a>', classes: 'govuk-tag--link govuk-tag--turquoise' })
+          },
+          value: {
+            html: '
+              <p class="govuk-!-margin-bottom-1">Against ex-partner</p>
+            '
+          }
+        }
+      ]
+    }) }}
 
-                {% if case.currentOrder.requirements.ap %}
-                <h3 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-                  Accredited Programme
-                </h3>
-                <p class="govuk-!-margin-bottom-0">
-                  {{ case.currentOrder.requirements.ap.value }}
-                </p>
-              {% endif %}-->
-      </div>
-      <p>
-        <a href="/cases/{{ CRN }}/sentence">View sentence</a>
-      </p>
-    </div>
-    <br><br>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-m">
       Risks

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -56,43 +56,25 @@
       Risk flags
     </h2>
 
-    <p><a href="#">Add, review or remove flags</a></p>
+    <p><a href="/cases/{{ CRN }}/flags">Add, review or remove flags</a></p>
 
-    {{ govukSummaryList({
-      classes: 'govuk-summary-list--no-border',
-      rows: [
-        {
-          key: {
-            html: govukTag({ html: '<a href="#">Registered sex offender</a>', classes: 'govuk-tag--link govuk-tag--purple' })
-          },
-          value: {
-            html: '
-              <p>Possession of indecent images</p>
-            '
-          }
-        },
-        {
-          key: {
-            html: govukTag({ html: '<a href="#">MAPPA</a>', classes: 'govuk-tag--link govuk-tag--purple' })
-          },
-          value: {
-            html: '
-              <p class="govuk-!-margin-bottom-1">Level 2, Category 3</p>
-            '
-          }
-        },
-        {
-          key: {
-            html: govukTag({ html: '<a href="#">Restraining order</a>', classes: 'govuk-tag--link govuk-tag--turquoise' })
-          },
-          value: {
-            html: '
-              <p class="govuk-!-margin-bottom-1">Against ex-partner</p>
-            '
-          }
-        }
-      ]
-    }) }}
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+      {% for flag in case.riskBadges %}
+        {% if not flag.rosh %}
+          {% set tagHtml %}
+            <a href="/cases/{{ CRN }}/flag/{{ flag.text | toSlug }}">{{ flag.text }}</a>
+          {% endset %}
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              {{ govukTag({ html: tagHtml, classes: 'govuk-tag--link govuk-tag--' + flag.class }) }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ flag.notes }}
+            </dd>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </dl>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4121,8 +4121,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4140,13 +4139,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4159,18 +4156,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4273,8 +4267,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4284,7 +4277,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4297,20 +4289,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4327,7 +4316,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4400,8 +4388,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4411,7 +4398,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4487,8 +4473,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4518,7 +4503,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4536,7 +4520,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4575,13 +4558,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -10160,6 +10141,11 @@
           "dev": true
         }
       }
+    },
+    "slugify": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.3.tgz",
+      "integrity": "sha512-/HkjRdwPY3yHJReXu38NiusZw2+LLE2SrhkWJtmlPDB1fqFSvioYj62NkPcrKiNCgRLeGcGK7QBvr1iQwybeXw=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4842,9 +4842,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
-      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
+      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA=="
     },
     "govuk_frontend_toolkit": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "portscanner": "^2.1.1",
     "prompt": "^1.0.0",
     "require-dir": "^1.0.0",
+    "slugify": "^1.5.3",
     "sync-request": "^6.0.0",
     "timepicker": "^1.13.18",
     "universal-analytics": "^0.4.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express-writer": "0.0.4",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^3.11.0",
+    "govuk-frontend": "^3.12.0",
     "govuk_frontend_toolkit": "^7.5.0",
     "govuk_template_jinja": "^0.24.1",
     "gulp": "^4.0.0",


### PR DESCRIPTION
- Show list of flag details on overview
- Add risk flag tab
- Add risk pages

Includes:
- Adding more data to riskBadges in cases data (avoids refactoring that for now)
- Routing to individual flag pages
- Enables the design system's new link styles
- Experimental clickable-tag design

Notes:
- Only guidance for registered sex offender has been added so far
- No design for the ROSH flags yet
- Standard flag data, like categories and guidance needs to go somewhere
- No designs for seeing a flag's review
- No designs for reviewing a flag – probably deferred to Delius for MVP

| Case page | Risk flags | Risk flag |
| -- | -- | -- |
| ![localhost_3009_cases_E577913](https://user-images.githubusercontent.com/319055/120345378-56426c80-c2f2-11eb-9696-8d2f93c7c058.png) | ![localhost_3009_cases_E577913_flags](https://user-images.githubusercontent.com/319055/120345397-59d5f380-c2f2-11eb-8a77-c6e2e966acef.png) | ![localhost_3009_cases_E577913_flag_registered-sex-offender (1)](https://user-images.githubusercontent.com/319055/120345394-593d5d00-c2f2-11eb-9c75-20cf964f12b6.png) |
