### PR TITLE
Align personal circumstances prototype data with Delius reference data

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -25,7 +25,7 @@ module.exports = [
       'sexualOrientation': 'Heterosexual',
       'disabilitiesAndAdjustments': ['Autism spectrum condition'],
       'circumstances': {
-        'employment': 'Full-time employed',
+        'employment': 'Full-time employed (30 or more hours per week)',
         'housingStatus': 'Living with family',
         'safeguardingIssues': []
       }
@@ -854,7 +854,7 @@ module.exports = [
       'sexualOrientation': 'Heterosexual',
       'disabilitiesAndAdjustments': ['Attention Deficit Hyperactivity Disorder (ADHD)'],
       'circumstances': {
-        'employment': 'Full-time employed',
+        'employment': 'Full-time employed (30 or more hours per week)',
         'housingStatus': 'Living with family',
         'safeguardingIssues': []
       }
@@ -1055,7 +1055,7 @@ module.exports = [
       'sexualOrientation': 'Heterosexual',
       'disabilitiesAndAdjustments': [],
       'circumstances': {
-        'employment': 'Full-time employed',
+        'employment': 'Full-time employed (30 or more hours per week)',
         'housingStatus': 'Living with parents',
         'safeguardingIssues': []
       }
@@ -1473,7 +1473,7 @@ module.exports = [
       'sexualOrientation': 'Bisexual',
       'disabilitiesAndAdjustments': [],
       'circumstances': {
-        'employment': 'Part-time employment',
+        'employment': 'Part-time employed (under 16 hours per week)',
         'housingStatus': 'Living alone',
         'safeguardingIssues': []
       }

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -512,7 +512,7 @@ module.exports = [
       'circumstances': {
         'employment': 'Retired (receiving a pension)',
         'housingStatus': 'Householder (Owner - freehold or leasehold)',
-        'safeguardingIssues': ['Risk to "Adult at Risk"']
+        'safeguardingIssues': ['Referral to Safeguarding Team-Response Received']
       }
     },
     'personalContacts': [

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -26,7 +26,7 @@ module.exports = [
       'disabilitiesAndAdjustments': ['Autism spectrum condition'],
       'circumstances': {
         'employment': 'Full-time employed (30 or more hours per week)',
-        'housingStatus': 'Living with family',
+        'housingStatus': 'Friends/Family (settled)',
         'safeguardingIssues': []
       }
     },
@@ -855,7 +855,7 @@ module.exports = [
       'disabilitiesAndAdjustments': ['Attention Deficit Hyperactivity Disorder (ADHD)'],
       'circumstances': {
         'employment': 'Full-time employed (30 or more hours per week)',
-        'housingStatus': 'Living with family',
+        'housingStatus': 'Friends/Family (settled)',
         'safeguardingIssues': []
       }
     },
@@ -1056,7 +1056,7 @@ module.exports = [
       'disabilitiesAndAdjustments': [],
       'circumstances': {
         'employment': 'Full-time employed (30 or more hours per week)',
-        'housingStatus': 'Living with parents',
+        'housingStatus': 'Friends/Family (settled)',
         'safeguardingIssues': []
       }
     },
@@ -1474,7 +1474,7 @@ module.exports = [
       'disabilitiesAndAdjustments': [],
       'circumstances': {
         'employment': 'Part-time employed (under 16 hours per week)',
-        'housingStatus': 'Living alone',
+        'housingStatus': 'Rental accommodation - private rental',
         'safeguardingIssues': []
       }
     },


### PR DESCRIPTION
## Why?

* To ensure we're not accidentally presenting more specific information that we have on record
* To gather evidence whether the reference data labels in Delius meet user need or need content design in our service

Trello: https://trello.com/c/PZPK9zLu/529-align-service-user-personal-circumstances-in-the-prototype-with-delius-reference-data