### PR TITLE
Add the ability to generate fake cases in the prototype

### DIFF
--- a/app/data/fake-cases.js
+++ b/app/data/fake-cases.js
@@ -1,0 +1,8 @@
+const fakeCase = require('./generators/case')
+module.exports = (count) => {
+  const cases = []
+  for (var i = 0; i < count; i++) {
+    cases.push(fakeCase())
+  }
+  return cases
+}

--- a/app/data/generators/address.js
+++ b/app/data/generators/address.js
@@ -1,0 +1,8 @@
+module.exports = (faker) => {
+  return [
+    faker.address.streetAddress(),
+    faker.address.city(),
+    faker.address.county(),
+    faker.address.zipCode()
+  ]
+}

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -7,6 +7,7 @@ const personalContact = require('./personal-contact')
 const professionalContact = require('./professional-contact')
 const currentOrder = require('./current-order')
 const previousOrders = require('./previous-orders')
+const riskFlags = require('./risk-flags')
 const generatorHelpers = require('./generator-helpers')
 const serviceUser = person(faker)
 const serviceUserCurrentOrder = currentOrder(faker)
@@ -44,26 +45,12 @@ const _case = {
   currentOrder: serviceUserCurrentOrder,
   previousOrders: previousOrders(faker, serviceUserCurrentOrder, generatorHelpers),
   breachesCount: 0,
-  restrainingOrdersCount: 0
+  restrainingOrdersCount: 0,
+  riskBadges: riskFlags(faker)
 }
 
 module.exports = _case
 
-//   'riskBadges': [
-//     {
-//       text: 'Medium risk of harm',
-//       class: 'orange',
-//       rosh: true
-//     },
-//     {
-//       text: 'IOM',
-//       class: 'grey',
-//       notes: 'Cross-agency',
-//       reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
-//       dateAdded: helpers.happenedOn({ daysAgo: '175' }),
-//       mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
-//     }
-//   ],
 //   'riskOfSeriousHarmLevel': {
 //     text: 'Medium',
 //     class: 'orange'

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -1,0 +1,218 @@
+const path = require('path')
+const helpers = require(path.join(__dirname, '../../../lib/helpers.js'))
+const faker = require('faker')
+const { DateTime } = require('luxon')
+faker.locale = 'en_GB'
+
+const person = require('./person')
+const address = require('./address')
+const personalContact = require('./personal-contact')
+const professionalContact = require('./professional-contact')
+const serviceUser = person(faker)
+
+const _case = {
+  serviceUserPersonalDetails: {
+    'name': serviceUser.fullName,
+    'firstName': serviceUser.firstName,
+    'dateOfBirth': DateTime.fromJSDate(faker.date.between('1950-01-01', '2002-12-31')).toISODate(),
+    'address': address(faker),
+    'phone': '07700 900 077',
+    'email': serviceUser.email,
+    'aliases': [],
+    'preferredLanguage': 'English',
+    'nationality': 'British',
+    'ethnicity': 'White: British',
+    'religion': 'None',
+    'gender': serviceUser.gender,
+    'sexualOrientation': 'Heterosexual',
+    'disabilitiesAndAdjustments': ['Autism spectrum condition'],
+    'circumstances': {
+      'employment': 'Full-time employed (30 or more hours per week)',
+      'housingStatus': 'Friends/Family (settled)',
+      'safeguardingIssues': []
+    }
+  },
+  personalContacts: [
+    personalContact(faker)
+  ],
+  professionalContacts: [
+    professionalContact(faker)
+  ]
+}
+
+module.exports = _case
+
+//
+//
+//
+//   'professionalContacts': [
+//     {
+//       'name': 'Gary Millar',
+//       'phone': '0114 123 0000',
+//       'email': 'example@example.com',
+//       'provider': 'CPA South Yorkshire',
+//       'localDeliveryUnit': 'Rotherham',
+//       'team': 'Rotherham LMC',
+//       'allocatedUntilDate': '2019-11-19'
+//     }
+//   ],
+//   'PNC': '2012/123400000F',
+//   'CRN': 'J678910',
+//   'currentOrder': {
+//     'type': 'Community Order',
+//     'description': 'Using violence to secure entry (Criminal Law Act/CJ and Public Order Act) - 19563',
+//     'lengthInMonths': 12,
+//     'progressInMonths': 6,
+//     'startDate': '2021-01-05',
+//     'endDate': helpers.sentenceEndDate({lengthInMonths: 12, startDate: '2021-01-05'}),
+//     'offenceDate': '2020-11-15',
+//     'convictionDate': '2020-12-12',
+//     'court': "Sheffield Magistrates' Court",
+//     'responsibleCourt': "Sheffield Magistrates' Court",
+//     'requirements': {
+//       'rar': {
+//         'type': 'RAR',
+//         'value': '15 days',
+//         'lengthInDays': 15,
+//         'progressInDays': 5
+//       },
+//       'fine': {
+//         'type': 'Fine',
+//         'value': '£1000'
+//       }
+//     },
+//     'courtDocuments': [
+//       {
+//         'name': 'Pre-sentence report',
+//         'lastUpdateDate': '2020-12-03'
+//       }
+//     ],
+//     'personalDocuments': [
+//       {
+//         'name': 'Induction pack',
+//         'lastUpdateDate': '2020-12-03'
+//       }
+//     ]
+//   },
+//   'previousOrders': [
+//     {
+//       'title': 'ORA Community Order (12 Months)',
+//       'description': 'Careless driving - 80400',
+//       'endDate': '2018-05-17'
+//     }
+//   ],
+//   'breachesCount': 0,
+//   'restrainingOrdersCount': 0,
+//   'riskBadges': [
+//     {
+//       text: 'Medium risk of harm',
+//       class: 'orange',
+//       rosh: true
+//     },
+//     {
+//       text: 'IOM',
+//       class: 'grey',
+//       notes: 'Cross-agency',
+//       reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+//       dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+//       mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
+//     }
+//   ],
+//   'riskOfSeriousHarmLevel': {
+//     text: 'Medium',
+//     class: 'orange'
+//   },
+//   'riskOfHarm': [
+//     {
+//       'riskTo': 'Themselves',
+//       'inCommunity': {
+//         text: 'Low',
+//         class: 'green'
+//       },
+//       'inCustody': {
+//         text: 'Low',
+//         class: 'green'
+//       }
+//     },
+//     {
+//       'riskTo': 'Children',
+//       'inCommunity': {
+//         text: 'Low',
+//         class: 'green'
+//       },
+//       'inCustody': {
+//         text: 'Low',
+//         class: 'green'
+//       }
+//     },
+//     {
+//       'riskTo': 'Public',
+//       'inCommunity': {
+//         text: 'Medium',
+//         class: 'orange'
+//       },
+//       'inCustody': {
+//         text: 'Low',
+//         class: 'green'
+//       }
+//     },
+//     {
+//       'riskTo': 'Known adult',
+//       'inCommunity': {
+//         text: 'Medium',
+//         class: 'orange'
+//       },
+//       'inCustody': {
+//         text: 'Low',
+//         class: 'green'
+//       }
+//     },
+//     {
+//       'riskTo': 'Staff',
+//       'inCommunity': {
+//         text: 'Low',
+//         class: 'green'
+//       },
+//       'inCustody': {
+//         text: 'Low',
+//         class: 'green'
+//       }
+//     },
+//     {
+//       'riskTo': 'Prisoners',
+//       'inCommunity': {
+//         text: 'Low',
+//         class: 'green'
+//       },
+//       'inCustody': {
+//         text: 'Low',
+//         class: 'green'
+//       }
+//     }
+//   ],
+//   'criminogenicNeeds': [
+//     'Relationships',
+//     'Thinking and attitudes'
+//   ],
+//   'status': 'Previously known',
+//   'previousOrderStatus': 'Order ended 24 Nov 2016',
+//   'appointmentStatistics': {
+//     'complied': 9,
+//     'acceptableAbsence': 0,
+//     'failureToComply': 1
+//   },
+//   'contactHistory': [
+//     {
+//       'type': 'Appointment',
+//       'type-of-session': 'Office visit',
+//       'lastUpdatedBy': 'Mark Berridge',
+//       'timestamp': helpers.happeningIn({ daysLater: 25, atTime: '13:00' }),
+//       'session-date': helpers.happeningIn({ daysLater: 25 }),
+//       'session-start-time': '1pm',
+//       'session-end-time': '1:30pm',
+//       'repeating': 'No, it’s a one-off session',
+//       'session-counts-towards-rar': 'No',
+//       'sessionId': 459
+//     }
+//   ]
+// },

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -7,10 +7,12 @@ const personalContact = require('./personal-contact')
 const professionalContact = require('./professional-contact')
 const currentOrder = require('./current-order')
 const previousOrders = require('./previous-orders')
-const riskFlags = require('./risk-flags')
+const risk = require('./risk')
 const generatorHelpers = require('./generator-helpers')
+
 const serviceUser = person(faker)
 const serviceUserCurrentOrder = currentOrder(faker)
+const serviceUserRisk = risk(faker)
 
 const _case = {
   serviceUserPersonalDetails: {
@@ -46,83 +48,13 @@ const _case = {
   previousOrders: previousOrders(faker, serviceUserCurrentOrder, generatorHelpers),
   breachesCount: 0,
   restrainingOrdersCount: 0,
-  riskBadges: riskFlags(faker)
+  riskBadges: serviceUserRisk.riskFlags,
+  riskOfSeriousHarmLevel: serviceUserRisk.riskOfSeriousHarmLevel,
+  riskOfHarm: serviceUserRisk.riskOfHarm
 }
 
 module.exports = _case
 
-//   'riskOfSeriousHarmLevel': {
-//     text: 'Medium',
-//     class: 'orange'
-//   },
-//   'riskOfHarm': [
-//     {
-//       'riskTo': 'Themselves',
-//       'inCommunity': {
-//         text: 'Low',
-//         class: 'green'
-//       },
-//       'inCustody': {
-//         text: 'Low',
-//         class: 'green'
-//       }
-//     },
-//     {
-//       'riskTo': 'Children',
-//       'inCommunity': {
-//         text: 'Low',
-//         class: 'green'
-//       },
-//       'inCustody': {
-//         text: 'Low',
-//         class: 'green'
-//       }
-//     },
-//     {
-//       'riskTo': 'Public',
-//       'inCommunity': {
-//         text: 'Medium',
-//         class: 'orange'
-//       },
-//       'inCustody': {
-//         text: 'Low',
-//         class: 'green'
-//       }
-//     },
-//     {
-//       'riskTo': 'Known adult',
-//       'inCommunity': {
-//         text: 'Medium',
-//         class: 'orange'
-//       },
-//       'inCustody': {
-//         text: 'Low',
-//         class: 'green'
-//       }
-//     },
-//     {
-//       'riskTo': 'Staff',
-//       'inCommunity': {
-//         text: 'Low',
-//         class: 'green'
-//       },
-//       'inCustody': {
-//         text: 'Low',
-//         class: 'green'
-//       }
-//     },
-//     {
-//       'riskTo': 'Prisoners',
-//       'inCommunity': {
-//         text: 'Low',
-//         class: 'green'
-//       },
-//       'inCustody': {
-//         text: 'Low',
-//         class: 'green'
-//       }
-//     }
-//   ],
 //   'criminogenicNeeds': [
 //     'Relationships',
 //     'Thinking and attitudes'

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -37,27 +37,13 @@ const _case = {
   ],
   professionalContacts: [
     professionalContact(faker)
-  ]
+  ],
+  'PNC': `${faker.datatype.number({ min: 1980, max: 2021 })}/${faker.datatype.number({ min: 1000000, max: 1300000 })}${faker.random.alpha(1).toUpperCase()}`, // 2012/12340000F
+  'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}` // J123456
 }
 
 module.exports = _case
 
-//
-//
-//
-//   'professionalContacts': [
-//     {
-//       'name': 'Gary Millar',
-//       'phone': '0114 123 0000',
-//       'email': 'example@example.com',
-//       'provider': 'CPA South Yorkshire',
-//       'localDeliveryUnit': 'Rotherham',
-//       'team': 'Rotherham LMC',
-//       'allocatedUntilDate': '2019-11-19'
-//     }
-//   ],
-//   'PNC': '2012/123400000F',
-//   'CRN': 'J678910',
 //   'currentOrder': {
 //     'type': 'Community Order',
 //     'description': 'Using violence to secure entry (Criminal Law Act/CJ and Public Order Act) - 19563',

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -50,22 +50,23 @@ const _case = {
   restrainingOrdersCount: 0,
   riskBadges: serviceUserRisk.riskFlags,
   riskOfSeriousHarmLevel: serviceUserRisk.riskOfSeriousHarmLevel,
-  riskOfHarm: serviceUserRisk.riskOfHarm
+  riskOfHarm: serviceUserRisk.riskOfHarm,
+  'criminogenicNeeds': [
+    'Relationships',
+    'Thinking and attitudes'
+  ],
+  status: 'Previously known',
+  previousOrderStatus: 'Order ended 24 Nov 2016',
+  appointmentStatistics: {
+    complied: 9,
+    acceptableAbsence: 0,
+    failureToComply: 1
+  },
+  contactHistory: []
 }
 
 module.exports = _case
 
-//   'criminogenicNeeds': [
-//     'Relationships',
-//     'Thinking and attitudes'
-//   ],
-//   'status': 'Previously known',
-//   'previousOrderStatus': 'Order ended 24 Nov 2016',
-//   'appointmentStatistics': {
-//     'complied': 9,
-//     'acceptableAbsence': 0,
-//     'failureToComply': 1
-//   },
 //   'contactHistory': [
 //     {
 //       'type': 'Appointment',

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -1,3 +1,5 @@
+const path = require('path')
+const helpers = require(path.join(__dirname, '../../../lib/helpers.js'))
 const faker = require('faker')
 faker.locale = 'en_GB'
 
@@ -10,75 +12,77 @@ const previousOrders = require('./previous-orders')
 const risk = require('./risk')
 const generatorHelpers = require('./generator-helpers')
 
-const serviceUser = person(faker)
-const serviceUserCurrentOrder = currentOrder(faker)
-const serviceUserRisk = risk(faker)
+module.exports = generateCase => {
+  const serviceUser = person(faker)
+  const serviceUserCurrentOrder = currentOrder(faker)
+  const serviceUserRisk = risk(faker)
 
-const _case = {
-  serviceUserPersonalDetails: {
-    'name': serviceUser.fullName,
-    'firstName': serviceUser.firstName,
-    'dateOfBirth': generatorHelpers.toISODate(faker.date.between('1950-01-01', '2002-12-31')),
-    'address': address(faker),
-    'phone': '07700 900 077',
-    'email': serviceUser.email,
-    'aliases': [],
-    'preferredLanguage': 'English',
-    'nationality': 'British',
-    'ethnicity': 'White: British',
-    'religion': 'None',
-    'gender': serviceUser.gender,
-    'sexualOrientation': 'Heterosexual',
-    'disabilitiesAndAdjustments': ['Autism spectrum condition'],
-    'circumstances': {
-      'employment': 'Full-time employed (30 or more hours per week)',
-      'housingStatus': 'Friends/Family (settled)',
-      'safeguardingIssues': []
-    }
-  },
-  personalContacts: [
-    personalContact(faker)
-  ],
-  professionalContacts: [
-    professionalContact(faker, generatorHelpers)
-  ],
-  'PNC': `${faker.datatype.number({ min: 1980, max: 2021 })}/${faker.datatype.number({ min: 1000000, max: 1300000 })}${faker.random.alpha(1).toUpperCase()}`, // 2012/12340000F
-  'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}`, // J123456
-  currentOrder: serviceUserCurrentOrder,
-  previousOrders: previousOrders(faker, serviceUserCurrentOrder, generatorHelpers),
-  breachesCount: 0,
-  restrainingOrdersCount: 0,
-  riskBadges: serviceUserRisk.riskFlags,
-  riskOfSeriousHarmLevel: serviceUserRisk.riskOfSeriousHarmLevel,
-  riskOfHarm: serviceUserRisk.riskOfHarm,
-  'criminogenicNeeds': [
-    'Relationships',
-    'Thinking and attitudes'
-  ],
-  status: 'Previously known',
-  previousOrderStatus: 'Order ended 24 Nov 2016',
-  appointmentStatistics: {
-    complied: 9,
-    acceptableAbsence: 0,
-    failureToComply: 1
-  },
-  contactHistory: []
+  const _case = {
+    serviceUserPersonalDetails: {
+      'name': serviceUser.fullName,
+      'firstName': serviceUser.firstName,
+      'dateOfBirth': generatorHelpers.toISODate(faker.date.between('1950-01-01', '2002-12-31')),
+      'address': address(faker),
+      'phone': '07700 900 077',
+      'email': serviceUser.email,
+      'aliases': [],
+      'preferredLanguage': 'English',
+      'nationality': 'British',
+      'ethnicity': 'White: British',
+      'religion': 'None',
+      'gender': serviceUser.gender,
+      'sexualOrientation': 'Heterosexual',
+      'disabilitiesAndAdjustments': ['Autism spectrum condition'],
+      'circumstances': {
+        'employment': 'Full-time employed (30 or more hours per week)',
+        'housingStatus': 'Friends/Family (settled)',
+        'safeguardingIssues': []
+      }
+    },
+    personalContacts: [
+      personalContact(faker)
+    ],
+    professionalContacts: [
+      professionalContact(faker, generatorHelpers)
+    ],
+    'PNC': `${faker.datatype.number({ min: 1980, max: 2021 })}/${faker.datatype.number({ min: 1000000, max: 1300000 })}${faker.random.alpha(1).toUpperCase()}`, // 2012/12340000F
+    'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}`, // J123456
+    currentOrder: serviceUserCurrentOrder,
+    previousOrders: previousOrders(faker, serviceUserCurrentOrder, generatorHelpers),
+    breachesCount: 0,
+    restrainingOrdersCount: 0,
+    riskBadges: serviceUserRisk.riskFlags,
+    riskOfSeriousHarmLevel: serviceUserRisk.riskOfSeriousHarmLevel,
+    riskOfHarm: serviceUserRisk.riskOfHarm,
+    'criminogenicNeeds': [
+      'Relationships',
+      'Thinking and attitudes'
+    ],
+    status: 'Previously known',
+    previousOrderStatus: 'Order ended 24 Nov 2016',
+    appointmentStatistics: {
+      complied: 9,
+      acceptableAbsence: 0,
+      failureToComply: 1
+    },
+    contactHistory: [
+      {
+        'type': 'Appointment',
+        'type-of-session': 'Office visit',
+        'lastUpdatedBy': 'Mark Berridge',
+        'timestamp': helpers.happeningIn({ daysLater: 25, atTime: '13:00' }),
+        'session-date': helpers.happeningIn({ daysLater: 25 }),
+        'session-start-time': '1pm',
+        'session-end-time': '1:30pm',
+        'repeating': 'No, it’s a one-off session',
+        'session-counts-towards-rar': 'No',
+        'sessionId': 459
+      }
+    ]
+  }
+
+  return _case
 }
 
-module.exports = _case
-
-//   'contactHistory': [
-//     {
-//       'type': 'Appointment',
-//       'type-of-session': 'Office visit',
-//       'lastUpdatedBy': 'Mark Berridge',
-//       'timestamp': helpers.happeningIn({ daysLater: 25, atTime: '13:00' }),
-//       'session-date': helpers.happeningIn({ daysLater: 25 }),
-//       'session-start-time': '1pm',
-//       'session-end-time': '1:30pm',
-//       'repeating': 'No, it’s a one-off session',
-//       'session-counts-towards-rar': 'No',
-//       'sessionId': 459
-//     }
-//   ]
+//   'contactHistory':
 // },

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -5,6 +5,7 @@ const person = require('./person')
 const address = require('./address')
 const personalContact = require('./personal-contact')
 const professionalContact = require('./professional-contact')
+const currentOrder = require('./current-order')
 const generatorHelpers = require('./generator-helpers')
 const serviceUser = person(faker)
 
@@ -37,7 +38,8 @@ const _case = {
     professionalContact(faker, generatorHelpers)
   ],
   'PNC': `${faker.datatype.number({ min: 1980, max: 2021 })}/${faker.datatype.number({ min: 1000000, max: 1300000 })}${faker.random.alpha(1).toUpperCase()}`, // 2012/12340000F
-  'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}` // J123456
+  'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}`, // J123456
+  currentOrder: currentOrder(faker)
 }
 
 module.exports = _case

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -1,20 +1,18 @@
-const path = require('path')
-const helpers = require(path.join(__dirname, '../../../lib/helpers.js'))
 const faker = require('faker')
-const { DateTime } = require('luxon')
 faker.locale = 'en_GB'
 
 const person = require('./person')
 const address = require('./address')
 const personalContact = require('./personal-contact')
 const professionalContact = require('./professional-contact')
+const generatorHelpers = require('./generator-helpers')
 const serviceUser = person(faker)
 
 const _case = {
   serviceUserPersonalDetails: {
     'name': serviceUser.fullName,
     'firstName': serviceUser.firstName,
-    'dateOfBirth': DateTime.fromJSDate(faker.date.between('1950-01-01', '2002-12-31')).toISODate(),
+    'dateOfBirth': generatorHelpers.toISODate(faker.date.between('1950-01-01', '2002-12-31')),
     'address': address(faker),
     'phone': '07700 900 077',
     'email': serviceUser.email,
@@ -36,7 +34,7 @@ const _case = {
     personalContact(faker)
   ],
   professionalContacts: [
-    professionalContact(faker)
+    professionalContact(faker, generatorHelpers)
   ],
   'PNC': `${faker.datatype.number({ min: 1980, max: 2021 })}/${faker.datatype.number({ min: 1000000, max: 1300000 })}${faker.random.alpha(1).toUpperCase()}`, // 2012/12340000F
   'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}` // J123456

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -6,8 +6,10 @@ const address = require('./address')
 const personalContact = require('./personal-contact')
 const professionalContact = require('./professional-contact')
 const currentOrder = require('./current-order')
+const previousOrders = require('./previous-orders')
 const generatorHelpers = require('./generator-helpers')
 const serviceUser = person(faker)
+const serviceUserCurrentOrder = currentOrder(faker)
 
 const _case = {
   serviceUserPersonalDetails: {
@@ -39,56 +41,14 @@ const _case = {
   ],
   'PNC': `${faker.datatype.number({ min: 1980, max: 2021 })}/${faker.datatype.number({ min: 1000000, max: 1300000 })}${faker.random.alpha(1).toUpperCase()}`, // 2012/12340000F
   'CRN': `${faker.random.alpha(1).toUpperCase()}${faker.datatype.number({ min: 100000, max: 999999 })}`, // J123456
-  currentOrder: currentOrder(faker)
+  currentOrder: serviceUserCurrentOrder,
+  previousOrders: previousOrders(faker, serviceUserCurrentOrder, generatorHelpers),
+  breachesCount: 0,
+  restrainingOrdersCount: 0
 }
 
 module.exports = _case
 
-//   'currentOrder': {
-//     'type': 'Community Order',
-//     'description': 'Using violence to secure entry (Criminal Law Act/CJ and Public Order Act) - 19563',
-//     'lengthInMonths': 12,
-//     'progressInMonths': 6,
-//     'startDate': '2021-01-05',
-//     'endDate': helpers.sentenceEndDate({lengthInMonths: 12, startDate: '2021-01-05'}),
-//     'offenceDate': '2020-11-15',
-//     'convictionDate': '2020-12-12',
-//     'court': "Sheffield Magistrates' Court",
-//     'responsibleCourt': "Sheffield Magistrates' Court",
-//     'requirements': {
-//       'rar': {
-//         'type': 'RAR',
-//         'value': '15 days',
-//         'lengthInDays': 15,
-//         'progressInDays': 5
-//       },
-//       'fine': {
-//         'type': 'Fine',
-//         'value': '£1000'
-//       }
-//     },
-//     'courtDocuments': [
-//       {
-//         'name': 'Pre-sentence report',
-//         'lastUpdateDate': '2020-12-03'
-//       }
-//     ],
-//     'personalDocuments': [
-//       {
-//         'name': 'Induction pack',
-//         'lastUpdateDate': '2020-12-03'
-//       }
-//     ]
-//   },
-//   'previousOrders': [
-//     {
-//       'title': 'ORA Community Order (12 Months)',
-//       'description': 'Careless driving - 80400',
-//       'endDate': '2018-05-17'
-//     }
-//   ],
-//   'breachesCount': 0,
-//   'restrainingOrdersCount': 0,
 //   'riskBadges': [
 //     {
 //       text: 'Medium risk of harm',

--- a/app/data/generators/current-order.js
+++ b/app/data/generators/current-order.js
@@ -1,0 +1,58 @@
+const path = require('path')
+const helpers = require(path.join(__dirname, '../../../lib/helpers.js'))
+const { DateTime } = require('luxon')
+
+module.exports = (faker) => {
+  const lengthInYears = faker.random.arrayElement([4, 3, 2, 1, 0.5])
+  const lengthInMonths = lengthInYears * 12
+  const progressInMonths = faker.datatype.number({ min: 1, max: lengthInMonths - 2 })
+  const startDate = DateTime.now().minus({ months: progressInMonths })
+
+  // Work backwords to a fake offence date
+  const offenceInMonthsBeforeStartDate = faker.datatype.number({ min: 6, max: 120 })
+  const offenceDate = startDate.minus({ months: offenceInMonthsBeforeStartDate }).toISODate()
+
+  // Work backwords to a conviction date
+  const convictionInDaysBeforeStartDate = faker.datatype.number({ min: 1, max: 35 })
+  const convictionDate = startDate.minus({ days: convictionInDaysBeforeStartDate }).toISODate()
+
+  const rarDays = faker.random.arrayElement([5, 10, 15, 20, 30])
+  const rarDaysProgress = faker.datatype.number({ min: 1, max: rarDays - 2 })
+
+  return {
+    'type': 'Community Order',
+    'description': 'Using violence to secure entry (Criminal Law Act/CJ and Public Order Act) - 19563',
+    'lengthInMonths': lengthInMonths,
+    'progressInMonths': progressInMonths,
+    'startDate': startDate.toISODate(),
+    'endDate': helpers.sentenceEndDate({ lengthInMonths: lengthInMonths, startDate: startDate.toISODate() }),
+    'offenceDate': offenceDate,
+    'convictionDate': convictionDate,
+    'court': "Sheffield Magistrates' Court",
+    'responsibleCourt': "Sheffield Magistrates' Court",
+    'requirements': {
+      'rar': {
+        'type': 'RAR',
+        'value': `${rarDays} days`,
+        'lengthInDays': rarDays,
+        'progressInDays': rarDaysProgress
+      },
+      'fine': {
+        'type': 'Fine',
+        'value': '£1000'
+      }
+    },
+    'courtDocuments': [
+      {
+        'name': 'Pre-sentence report',
+        'lastUpdateDate': convictionDate
+      }
+    ],
+    'personalDocuments': [
+      {
+        'name': 'Induction pack',
+        'lastUpdateDate': convictionDate
+      }
+    ]
+  }
+}

--- a/app/data/generators/generator-helpers.js
+++ b/app/data/generators/generator-helpers.js
@@ -1,0 +1,8 @@
+const { DateTime } = require('luxon')
+
+module.exports = {
+  toISODate: (jsDate) => {
+    // 2021-01-01
+    return DateTime.fromJSDate(jsDate).toISODate()
+  }
+}

--- a/app/data/generators/person.js
+++ b/app/data/generators/person.js
@@ -1,0 +1,8 @@
+module.exports = (faker) => {
+  const gender = faker.random.arrayElement(['Male', 'Male', 'Male', 'Male', 'Female'])
+  const firstName = faker.name.firstName(gender)
+  const lastName = faker.name.lastName(gender)
+  const fullName = `${firstName} ${lastName}`
+  const email = faker.internet.exampleEmail(firstName, lastName)
+  return { gender, firstName, lastName, fullName, email }
+}

--- a/app/data/generators/personal-contact.js
+++ b/app/data/generators/personal-contact.js
@@ -1,0 +1,14 @@
+const person = require('./person')
+const address = require('./address')
+
+module.exports = (faker) => {
+  const personalContact = person(faker)
+  const possibleRelationships = personalContact.gender === 'Male' ? ['Dad', 'Brother'] : ['Mum', 'Sister']
+
+  return {
+    'name': personalContact.fullName,
+    'relationship': faker.random.arrayElement(possibleRelationships),
+    'address': address(faker),
+    'phone': '07700 900 141'
+  }
+}

--- a/app/data/generators/previous-orders.js
+++ b/app/data/generators/previous-orders.js
@@ -1,0 +1,9 @@
+module.exports = (faker, currentOrder, generatorHelpers) => {
+  return [
+    {
+      'title': 'ORA Community Order (12 Months)',
+      'description': 'Careless driving - 80400',
+      'endDate': generatorHelpers.toISODate(faker.date.between('1999-01-01', currentOrder.convictionDate))
+    }
+  ]
+}

--- a/app/data/generators/professional-contact.js
+++ b/app/data/generators/professional-contact.js
@@ -1,7 +1,6 @@
 const person = require('./person')
-const { DateTime } = require('luxon')
 
-module.exports = (faker) => {
+module.exports = (faker, generatorHelpers) => {
   const professionalContact = person(faker)
   const years = 2
 
@@ -12,6 +11,6 @@ module.exports = (faker) => {
     'provider': 'CPA South Yorkshire',
     'localDeliveryUnit': 'Rotherham',
     'team': 'Rotherham LMC',
-    'allocatedUntilDate': DateTime.fromJSDate(faker.date.past(years)).toISODate()
+    'allocatedUntilDate': generatorHelpers.toISODate(faker.date.past(years))
   }
 }

--- a/app/data/generators/professional-contact.js
+++ b/app/data/generators/professional-contact.js
@@ -1,0 +1,17 @@
+const person = require('./person')
+const { DateTime } = require('luxon')
+
+module.exports = (faker) => {
+  const professionalContact = person(faker)
+  const years = 2
+
+  return {
+    'name': professionalContact.fullName,
+    'phone': '0114 123 0000',
+    'email': professionalContact.email,
+    'provider': 'CPA South Yorkshire',
+    'localDeliveryUnit': 'Rotherham',
+    'team': 'Rotherham LMC',
+    'allocatedUntilDate': DateTime.fromJSDate(faker.date.past(years)).toISODate()
+  }
+}

--- a/app/data/generators/risk-flags.js
+++ b/app/data/generators/risk-flags.js
@@ -1,0 +1,56 @@
+const path = require('path')
+const helpers = require(path.join(__dirname, '../../../lib/helpers.js'))
+
+module.exports = (faker) => {
+  const flags = [
+    {
+      text: 'IOM',
+      class: 'grey',
+      notes: 'Cross-agency',
+      reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+      dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+      mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
+    },
+    {
+      text: 'Registered sex offender',
+      class: 'purple',
+      notes: 'Possession of indecent images',
+      reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+      dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+      mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
+    },
+    {
+      text: 'MAPPA',
+      class: 'purple',
+      notes: 'Level 2, Category 3',
+      reviewDue: helpers.happenedOn({ daysAgo: '1' }),
+      dateAdded: helpers.happenedOn({ daysAgo: '91' })
+    },
+    {
+      text: 'Restraining order',
+      class: 'turquoise',
+      notes: 'Against ex-partner',
+      reviewDue: helpers.happeningIn({ daysLater: 60, atTime: '13:00' }),
+      dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+      mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
+    },
+    {
+      text: 'Domestic abuse',
+      class: 'turquoise',
+      notes: 'Partner is the victim',
+      reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
+      dateAdded: helpers.happenedOn({ daysAgo: '175' }),
+      mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
+    }
+  ]
+
+  const numberOfFlags = faker.datatype.number({ min: 1, max: 4 })
+  const randomFlags = faker.helpers.shuffle(flags).slice(0, numberOfFlags)
+  randomFlags.unshift({
+    text: 'Medium risk of harm',
+    class: 'orange',
+    rosh: true
+  })
+
+  return randomFlags
+}

--- a/app/data/generators/risk.js
+++ b/app/data/generators/risk.js
@@ -2,7 +2,45 @@ const path = require('path')
 const helpers = require(path.join(__dirname, '../../../lib/helpers.js'))
 
 module.exports = (faker) => {
-  const flags = [
+  const high = { text: 'High', class: 'red' }
+  const medium = { text: 'Medium', class: 'orange' }
+  const low = { text: 'Low', class: 'green' }
+
+  const riskOfSeriousHarmLevel = faker.random.arrayElement([high, medium, low])
+  const riskOfHarm = [
+    {
+      'riskTo': 'Themselves',
+      'inCommunity': faker.random.arrayElement([high, medium, low]),
+      'inCustody': faker.random.arrayElement([high, medium, low])
+    },
+    {
+      'riskTo': 'Children',
+      'inCommunity': faker.random.arrayElement([high, medium, low]),
+      'inCustody': faker.random.arrayElement([high, medium, low])
+    },
+    {
+      'riskTo': 'Public',
+      'inCommunity': faker.random.arrayElement([high, medium, low]),
+      'inCustody': faker.random.arrayElement([high, medium, low])
+    },
+    {
+      'riskTo': 'Known adult',
+      'inCommunity': faker.random.arrayElement([high, medium, low]),
+      'inCustody': faker.random.arrayElement([high, medium, low])
+    },
+    {
+      'riskTo': 'Staff',
+      'inCommunity': faker.random.arrayElement([high, medium, low]),
+      'inCustody': faker.random.arrayElement([high, medium, low])
+    },
+    {
+      'riskTo': 'Prisoners',
+      'inCommunity': faker.random.arrayElement([high, medium, low]),
+      'inCustody': faker.random.arrayElement([high, medium, low])
+    }
+  ]
+
+  const availableFlags = [
     {
       text: 'IOM',
       class: 'grey',
@@ -45,12 +83,13 @@ module.exports = (faker) => {
   ]
 
   const numberOfFlags = faker.datatype.number({ min: 1, max: 4 })
-  const randomFlags = faker.helpers.shuffle(flags).slice(0, numberOfFlags)
-  randomFlags.unshift({
-    text: 'Medium risk of harm',
-    class: 'orange',
+  const riskFlags = faker.helpers.shuffle(availableFlags).slice(0, numberOfFlags)
+
+  riskFlags.unshift({
+    text: `${riskOfSeriousHarmLevel.text} risk of harm`,
+    class: riskOfSeriousHarmLevel.class,
     rosh: true
   })
 
-  return randomFlags
+  return { riskOfSeriousHarmLevel, riskOfHarm, riskFlags }
 }

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,4 +1,5 @@
 const cases = require('./cases')
+const randomCase = require('./generators/case')
 
 const contactHistoryDefaults = (map, su) => {
   if (su.contactHistory) {
@@ -11,6 +12,7 @@ module.exports = {
   features: {
     filters: false
   },
+  'random-case': randomCase,
   'provider-code': 'N55', // Yorkshire and the Humber
   'team-codes': ['N55NIW'],
   'default-teams': {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,5 +1,5 @@
 const cases = require('./cases')
-const randomCase = require('./generators/case')
+const fakeCases = require('./fake-cases')
 
 const contactHistoryDefaults = (map, su) => {
   if (su.contactHistory) {
@@ -8,11 +8,12 @@ const contactHistoryDefaults = (map, su) => {
   return map
 }
 
+const sessionCases = cases.concat(fakeCases(10))
+
 module.exports = {
   features: {
     filters: false
   },
-  'random-case': randomCase,
   'provider-code': 'N55', // Yorkshire and the Humber
   'team-codes': ['N55NIW'],
   'default-teams': {
@@ -20,6 +21,6 @@ module.exports = {
     'N07': ['N07L10'],
     'N55': ['N55LNG']
   },
-  cases: cases,
-  'communication': cases.reduce(contactHistoryDefaults, {})
+  cases: sessionCases,
+  'communication': sessionCases.reduce(contactHistoryDefaults, {})
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3851,6 +3851,11 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
+    },
     "fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "express": "4.16.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
+    "faker": "^5.5.3",
     "fancy-log": "^1.3.3",
     "govuk-elements-sass": "^3.1.3",
     "govuk-frontend": "^3.12.0",


### PR DESCRIPTION
Allow us to generate cases or aspects of a case quickly.

Make it easier to:
- test designs with higher data volume
- spin up new test cases for certain design criteria
- see how the design responds to a variety of data

Doesn't yet generate a contact history (just an initial appointment)

This PR will append 10 generated cases to the end of the case list.