### PR TITLE
Changed "Completed orders" to "Previous orders"

### DIFF
--- a/app/views/case/_compliance-previous-orders.html
+++ b/app/views/case/_compliance-previous-orders.html
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8 govuk-!-margin-bottom-5">Completed orders (June 2019 to present)</h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8 govuk-!-margin-bottom-5">Previous orders (June 2019 to present)</h2>
 
 {% set firstOldOrder %}
   {{ govukSummaryList({


### PR DESCRIPTION
Following testing, we've changed this title to reflect that it's previous orders and not just those that were completed.