### PR TITLE
Fix [object].[object] on Overview page

### DIFF
--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -176,6 +176,21 @@
     <h2 class="govuk-heading-m">
       Personal details
     </h2>
+
+    {% set disabilities %}
+      {% if case.serviceUserPersonalDetails.disabilitiesAndAdjustments.length > 0 %}
+        <ul class="govuk-list">
+        {% for disability in case.serviceUserPersonalDetails.disabilitiesAndAdjustments %}
+          <li>
+            {{ disability.disability }}
+          </li>
+        {% endfor %}
+        </ul>
+      {% else %}
+        None
+      {% endif %}
+    {% endset %}
+
     {{ govukSummaryList({
       classes: 'govuk-summary-list--no-border',
       rows: [
@@ -184,8 +199,8 @@
           value: { text: case.serviceUserPersonalDetails.preferredLanguage }
         },
         {
-          key: { text: "Disabilities and adjustments" },
-          value: { text: case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') | default('<span class="govuk-hint-s">None known</span>', true) | safe }
+          key: { text: "Disabilities" },
+          value: { html: disabilities }
         }
       ]
       }) }}


### PR DESCRIPTION
This was introduced by #267.

This is a slight change to the design but the overview page will be revisited soon anyway.

Before:

![image](https://user-images.githubusercontent.com/23801/123663663-8700bd80-d82e-11eb-87c6-755a869b312e.png)

After:

![image](https://user-images.githubusercontent.com/23801/123663692-908a2580-d82e-11eb-8ccc-85e779f34898.png)

