### PR TITLE
Create pages for personal contacts

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -86,6 +86,7 @@ module.exports = [
       {
         'name': 'Pippa Wade',
         'relationship': 'Mum',
+        'relationshipType': 'Family member',
         'address': [
           '1 Grey Lane',
           'Sheffield',
@@ -637,6 +638,7 @@ module.exports = [
       {
         'name': 'Mary Bell',
         'relationship': 'Wife (separated)',
+        'relationshipType': 'Family member',
         'phone': '01274 773 355',
         'address': [
           '21 Valley Parade',
@@ -647,6 +649,7 @@ module.exports = [
       {
         'name': 'Lewis Wilson',
         'relationship': 'Son (30 years old)',
+        'relationshipType': 'Child',
         'phone': '01632 960130',
         'address': [
           '57 Whatlington Road',
@@ -1001,6 +1004,7 @@ module.exports = [
       {
         'name': 'Gerry Gil',
         'relationship': 'Dad',
+        'relationshipType': 'Family member',
         'address': [
           '27 Camber Road',
           'Leeds',
@@ -1217,6 +1221,7 @@ module.exports = [
       {
         'name': 'Shelly Davis',
         'relationship': 'Partner',
+        'relationshipType': 'Family member',
         'address': [
           '100 Drive Street',
           'Flat 10',
@@ -1227,6 +1232,7 @@ module.exports = [
       {
         'name': 'Bill and Sally Hart',
         'relationship': 'Parents',
+        'relationshipType': 'Family member',
         'address': [
           '94 Kendell Street',
           'Sheffield',
@@ -1652,6 +1658,7 @@ module.exports = [
       {
         'name': 'Shelly Davis',
         'relationship': 'Partner',
+        'relationshipType': 'Family member',
         'address': [
           '100 Drive Street',
           'Flat 10',
@@ -1662,6 +1669,7 @@ module.exports = [
       {
         'name': 'John Edwards',
         'relationship': 'Brother',
+        'relationshipType': 'Family member',
         'address': [
           '64 Pharetra Ave',
           'Blaydon',

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -94,6 +94,21 @@ module.exports = [
           'S10 1AG'
         ],
         'phone': '07700 900 141'
+      },
+      {
+        'name': 'Jonathan Wade',
+        'relationship': 'Dad',
+        'relationshipType': 'Emergency contact',
+        'address': [
+          '1 Grey Lane',
+          'Sheffield',
+          'South Yorkshire',
+          'S10 1AG'
+        ],
+        'phone': '07123456789',
+        'email': 'j.wade@example.com',
+        'startDate': '2021-01-01',
+        'notes': 'Dad is the best person to contact in an emergency'
       }
     ],
     'professionalContacts': [

--- a/app/data/generators/personal-contact.js
+++ b/app/data/generators/personal-contact.js
@@ -8,6 +8,7 @@ module.exports = (faker) => {
   return {
     'name': personalContact.fullName,
     'relationship': faker.random.arrayElement(possibleRelationships),
+    'relationshipType': 'Family member',
     'address': address(faker),
     'phone': '07700 900 141'
   }

--- a/app/routes/cases.js
+++ b/app/routes/cases.js
@@ -94,6 +94,15 @@ module.exports = router => {
     res.render('case/flag')
   })
 
+  router.all('/cases/:CRN/personal-contact/:contactSlug', function (req, res) {
+    const personalContacts = res.locals.case.personalContacts
+    const personalContact = personalContacts.find(contact => {
+      return slugify(contact.name, { lower: true }) === req.params.contactSlug
+    })
+    res.locals.personalContact = personalContact
+    res.render('case/personal-contact')
+  })
+
   router.all('/cases/:CRN/:view', function (req, res) {
     res.render(`case/${req.params.view}`)
   })

--- a/app/views/case/details.html
+++ b/app/views/case/details.html
@@ -66,7 +66,10 @@
         <ul class="govuk-list">
           {% for contact in case.personalContacts %}
             <li>
-              <a href="/cases/{{ CRN }}/personal-contact/{{ contact.name | toSlug }}">{{ contact.name }} – {{ contact.relationship }}</a>
+              <p>
+                {{ contact.relationshipType }}:<br />
+                <a href="/cases/{{ CRN }}/personal-contact/{{ contact.name | toSlug }}">{{ contact.name }} – {{ contact.relationship }}</a>
+              </p>
             </li>
           {% endfor %}
         </ul>

--- a/app/views/case/details.html
+++ b/app/views/case/details.html
@@ -66,7 +66,7 @@
         <ul class="govuk-list">
           {% for contact in case.personalContacts %}
             <li>
-              <a href="#">{{ contact.name }} – {{ contact.relationship }}</a>
+              <a href="/cases/{{ CRN }}/personal-contact/{{ contact.name | toSlug }}">{{ contact.name }} – {{ contact.relationship }}</a>
             </li>
           {% endfor %}
         </ul>

--- a/app/views/case/details.html
+++ b/app/views/case/details.html
@@ -61,28 +61,28 @@
       }) }}
     {% endset %}
 
-    {% set personalContacts %}
-      {% if case.personalContacts.length > 0 %}
-        <ul class="govuk-list">
-          {% for contact in case.personalContacts %}
-            <li>
-              <p>
-                {{ contact.relationshipType }}:<br />
-                <a href="/cases/{{ CRN }}/personal-contact/{{ contact.name | toSlug }}">{{ contact.name }} – {{ contact.relationship }}</a>
-              </p>
-            </li>
-          {% endfor %}
-        </ul>
-      {% else %}
-        None
-      {% endif %}
-    {% endset %}
-
     {{ govukDetails({
       summaryText: "View address details",
       classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-0',
       html: addressDetails
     }) }}
+  {% endset %}
+
+  {% set personalContacts %}
+    {% if case.personalContacts.length > 0 %}
+      <ul class="govuk-list">
+        {% for contact in case.personalContacts %}
+          <li>
+            <p>
+              {{ contact.relationshipType }}:<br />
+              <a href="/cases/{{ CRN }}/personal-contact/{{ contact.name | toSlug }}">{{ contact.name }} – {{ contact.relationship }}</a>
+            </p>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      None
+    {% endif %}
   {% endset %}
 
   {{ govukSummaryList({

--- a/app/views/case/personal-contact.html
+++ b/app/views/case/personal-contact.html
@@ -28,105 +28,50 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl">Personal contact</span>
+      <span class="govuk-caption-xl">{{ personalContact.relationshipType }}</span>
       {{ title }}
     </h1>
 
     {{ govukSummaryList({
       rows: [
         {
+          key: { text: "Name" },
+          value: { text: personalContact.name }
+        },
+        {
           key: { text: "Relationship type" },
-          value: { text: personalContact.relationshipType },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "relationship on National Delius"
-              }
-            ]
-          }
+          value: { text: personalContact.relationshipType }
         },
         {
           key: { text: "Relationship" },
-          value: { text: personalContact.relationship },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "relationship on National Delius"
-              }
-            ]
-          }
+          value: { text: personalContact.relationship }
         },
         {
           key: { text: "Address" },
-          value: { html: personalContact.address.join('<br>') },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "address on National Delius"
-              }
-            ]
-          }
+          value: { html: personalContact.address.join('<br>') }
         } if personalContact.address.length > 0,
         {
           key: { text: "Phone number" },
-          value: { html: personalContact.phone },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "phone number on National Delius"
-              }
-            ]
-          }
+          value: { html: personalContact.phone }
         } if personalContact.phone,
         {
           key: { text: "Email" },
-          value: { html: personalContact.email },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "phone number on National Delius"
-              }
-            ]
-          }
+          value: { html: personalContact.email }
         } if personalContact.email,
         {
           key: { text: "Start date" },
-          value: { html: personalContact.startDate | dateWithYear },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "phone number on National Delius"
-              }
-            ]
-          }
+          value: { html: personalContact.startDate | dateWithYear }
         } if personalContact.startDate,
         {
           key: { text: "Notes" },
-          value: { html: personalContact.notes if personalContact.notes else 'No notes' },
-          actions: {
-            items: [
-              {
-                href: "/to-delius",
-                text: "Change",
-                visuallyHiddenText: "phone number on National Delius"
-              }
-            ]
-          }
+          value: { html: personalContact.notes if personalContact.notes else 'No notes' }
         }
       ]
     }) }}
+
+    <p>
+      <a href="/to-delius">Change contact details</a>
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/app/views/case/personal-contact.html
+++ b/app/views/case/personal-contact.html
@@ -72,7 +72,7 @@
               }
             ]
           }
-        },
+        } if personalContact.address.length > 0,
         {
           key: { text: "Phone number" },
           value: { html: personalContact.phone },
@@ -85,7 +85,7 @@
               }
             ]
           }
-        },
+        } if personalContact.phone,
         {
           key: { text: "Email" },
           value: { html: personalContact.email },

--- a/app/views/case/personal-contact.html
+++ b/app/views/case/personal-contact.html
@@ -1,0 +1,132 @@
+{% extends "layout.html" %}
+{% set title = personalContact.name + ' – ' + personalContact.relationship %}
+{% block pageTitle %}{{ title }}{% endblock %}
+
+{% block beforeContent %}
+{{ govukBreadcrumbs({
+  items: [
+    {
+      text: "Cases",
+      href: "/cases"
+    },
+    {
+      text: case.serviceUserPersonalDetails.name,
+      href: "/cases/" + CRN
+    },
+    {
+      text: "Personal details",
+      href: "/cases/" + CRN + "/details"
+    },
+    {
+      text: "Personal contact: " + title
+    }
+  ]
+}) }}
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">Personal contact</span>
+      {{ title }}
+    </h1>
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: { text: "Relationship type" },
+          value: { text: personalContact.relationshipType },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "relationship on National Delius"
+              }
+            ]
+          }
+        },
+        {
+          key: { text: "Relationship" },
+          value: { text: personalContact.relationship },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "relationship on National Delius"
+              }
+            ]
+          }
+        },
+        {
+          key: { text: "Address" },
+          value: { html: personalContact.address.join('<br>') },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "address on National Delius"
+              }
+            ]
+          }
+        },
+        {
+          key: { text: "Phone number" },
+          value: { html: personalContact.phone },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "phone number on National Delius"
+              }
+            ]
+          }
+        },
+        {
+          key: { text: "Email" },
+          value: { html: personalContact.email },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "phone number on National Delius"
+              }
+            ]
+          }
+        } if personalContact.email,
+        {
+          key: { text: "Start date" },
+          value: { html: personalContact.startDate | dateWithYear },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "phone number on National Delius"
+              }
+            ]
+          }
+        } if personalContact.startDate,
+        {
+          key: { text: "Notes" },
+          value: { html: personalContact.notes if personalContact.notes else 'No notes' },
+          actions: {
+            items: [
+              {
+                href: "/to-delius",
+                text: "Change",
+                visuallyHiddenText: "phone number on National Delius"
+              }
+            ]
+          }
+        }
+      ]
+    }) }}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
- Add relationship type to personal details tab (and data)
- Create page for personal contacts
- Show extra Delius data in cases data

## Personal details tab
![Screen Shot 2021-07-01 at 10 18 52](https://user-images.githubusercontent.com/319055/124099862-d412a880-da55-11eb-99e4-69c730668e91.png)

## Personal contact page
![localhost_3012_cases_J678910_personal-contact_jonathan-wade (1)](https://user-images.githubusercontent.com/319055/124099915-e0970100-da55-11eb-9c7b-e3a33764368e.png)
