### PR TITLE
Refactor risk flags

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -244,23 +244,13 @@ module.exports = [
     'restrainingOrdersCount': 0,
     'riskFlags': [
       {
-        text: 'Very high risk of harm',
-        class: 'app-tag--dark-red',
-        rosh: true
-      },
-      {
-        text: 'IOM',
-        class: 'govuk-tag--grey',
+        ...helpers.getFlag('IIOM'),
         notes: 'Cross-agency',
         reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
         dateAdded: helpers.happenedOn({ daysAgo: '175' }),
         mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
-    'riskOfSeriousHarmLevel': {
-      text: 'Very high',
-      class: 'app-tag--dark-red'
-    },
     'riskOfHarm': [
       {
         'riskTo': 'Themselves',
@@ -770,38 +760,26 @@ module.exports = [
     'restrainingOrdersCount': 0,
     'riskFlags': [
       {
-        text: 'High risk of harm',
-        class: 'govuk-tag--red',
-        rosh: true
-      },
-      {
-        text: 'Registered sex offender',
-        class: 'govuk-tag--purple',
+        ...helpers.getFlag('ARSO'),
         notes: 'Possession of indecent images',
         reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
         dateAdded: helpers.happenedOn({ daysAgo: '175' }),
         mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       },
       {
-        text: 'MAPPA',
-        class: 'govuk-tag--purple',
+        ...helpers.getFlag('MAPP'),
         notes: 'Level 2, Category 3',
         reviewDue: helpers.happenedOn({ daysAgo: '1' }),
         dateAdded: helpers.happenedOn({ daysAgo: '91' })
       },
       {
-        text: 'Restraining order',
-        class: 'govuk-tag--turquoise',
+        ...helpers.getFlag('RSTO'),
         notes: 'Against ex-partner',
         reviewDue: helpers.happeningIn({ daysLater: 60, atTime: '13:00' }),
         dateAdded: helpers.happenedOn({ daysAgo: '175' }),
         mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
-    'riskOfSeriousHarmLevel': {
-      text: 'High',
-      class: 'govuk-tag--red'
-    },
     'riskOfHarm': [
       {
         'riskTo': 'Themselves',
@@ -1062,17 +1040,7 @@ module.exports = [
     'previousOrders': [],
     'breachesCount': 0,
     'restrainingOrdersCount': 0,
-    'riskFlags': [
-      {
-        text: 'Medium risk of harm',
-        class: 'govuk-tag--yellow',
-        rosh: true
-      }
-    ],
-    'riskOfSeriousHarmLevel': {
-      text: 'Medium',
-      class: 'govuk-tag--yellow'
-    },
+    'riskFlags': [],
     'riskOfHarm': [
       {
         'riskTo': 'Themselves',
@@ -1273,23 +1241,13 @@ module.exports = [
     'restrainingOrdersCount': 0,
     'riskFlags': [
       {
-        text: 'Medium risk of harm',
-        class: 'govuk-tag--yellow',
-        rosh: true
-      },
-      {
-        text: 'Domestic abuse',
-        class: 'govuk-tag--turquoise',
+        ...helpers.getFlag('ADVP'),
         notes: 'Partner is the victim',
         reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
         dateAdded: helpers.happenedOn({ daysAgo: '175' }),
         mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
-    'riskOfSeriousHarmLevel': {
-      text: 'Medium',
-      class: 'govuk-tag--yellow'
-    },
     'riskOfHarm': [
       {
         'riskTo': 'Themselves',
@@ -1678,23 +1636,13 @@ module.exports = [
     'restrainingOrdersCount': 1,
     'riskFlags': [
       {
-        text: 'Medium risk of harm',
-        class: 'govuk-tag--yellow',
-        rosh: true
-      },
-      {
-        text: 'Restraining Order',
-        class: 'govuk-tag--turquoise',
+        ...helpers.getFlag('RSTO'),
         notes: 'His ex-partner of 5 years has a restraining order against him due to repeated instances of domestic violence. She has changed address and works at a different location from when they lived together.',
         reviewDue: helpers.happeningIn({ daysLater: 5, atTime: '13:00' }),
         dateAdded: helpers.happenedOn({ daysAgo: '175' }),
         mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
     ],
-    'riskOfSeriousHarmLevel': {
-      text: 'Medium',
-      class: 'govuk-tag--yellow'
-    },
     'riskOfHarm': [
       {
         'riskTo': 'Themselves',

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -242,7 +242,7 @@ module.exports = [
     ],
     'breachesCount': 0,
     'restrainingOrdersCount': 0,
-    'riskBadges': [
+    'riskFlags': [
       {
         text: 'Very high risk of harm',
         class: 'app-tag--dark-red',
@@ -768,7 +768,7 @@ module.exports = [
     ],
     'breachesCount': 1,
     'restrainingOrdersCount': 0,
-    'riskBadges': [
+    'riskFlags': [
       {
         text: 'High risk of harm',
         class: 'govuk-tag--red',
@@ -1062,7 +1062,7 @@ module.exports = [
     'previousOrders': [],
     'breachesCount': 0,
     'restrainingOrdersCount': 0,
-    'riskBadges': [
+    'riskFlags': [
       {
         text: 'Medium risk of harm',
         class: 'govuk-tag--yellow',
@@ -1271,7 +1271,7 @@ module.exports = [
     ],
     'breachesCount': 0,
     'restrainingOrdersCount': 0,
-    'riskBadges': [
+    'riskFlags': [
       {
         text: 'Medium risk of harm',
         class: 'govuk-tag--yellow',
@@ -1676,7 +1676,7 @@ module.exports = [
     ],
     'breachesCount': 0,
     'restrainingOrdersCount': 1,
-    'riskBadges': [
+    'riskFlags': [
       {
         text: 'Medium risk of harm',
         class: 'govuk-tag--yellow',

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -779,7 +779,7 @@ module.exports = [
         dateAdded: helpers.happenedOn({ daysAgo: '175' }),
         mostRecentReviewDate: helpers.happenedOn({ daysAgo: '85' })
       }
-    ],
+    ].sort((a, b) => (a.text > b.text ? 1 : -1)),
     'riskOfHarm': [
       {
         'riskTo': 'Themselves',

--- a/app/data/generators/case.js
+++ b/app/data/generators/case.js
@@ -65,7 +65,7 @@ module.exports = generateCase => {
     previousOrders: previousOrders(faker, serviceUserCurrentOrder, generatorHelpers),
     breachesCount: 0,
     restrainingOrdersCount: 0,
-    riskBadges: serviceUserRisk.serviceUserRiskFlags,
+    riskFlags: serviceUserRisk.serviceUserRiskFlags,
     riskOfSeriousHarmLevel: serviceUserRisk.riskOfSeriousHarmLevel,
     riskOfHarm: serviceUserRisk.riskOfHarm,
     'criminogenicNeeds': [

--- a/app/data/generators/risk.js
+++ b/app/data/generators/risk.js
@@ -9,7 +9,6 @@ module.exports = (faker, generatorHelpers) => {
   const medium = { text: 'Medium', class: 'govuk-tag--yellow' }
   const low = { text: 'Low', class: 'govuk-tag--green' }
 
-  const riskOfSeriousHarmLevel = faker.random.arrayElement([veryHigh, high, medium, low])
   const riskOfHarm = [
     {
       'riskTo': 'Themselves',
@@ -62,12 +61,5 @@ module.exports = (faker, generatorHelpers) => {
     }
   })
 
-  // Put risk level flag first
-  serviceUserRiskFlags.unshift({
-    text: `${riskOfSeriousHarmLevel.text} risk of harm`,
-    class: riskOfSeriousHarmLevel.class,
-    rosh: true
-  })
-
-  return { riskOfSeriousHarmLevel, riskOfHarm, serviceUserRiskFlags }
+  return { riskOfHarm, serviceUserRiskFlags }
 }

--- a/app/data/reference/risk-flags.json
+++ b/app/data/reference/risk-flags.json
@@ -4,7 +4,7 @@
       "id": "WRSM",
       "text": "Warrant / Summons",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -12,7 +12,7 @@
       "id": "RCCO",
       "text": "Child Concerns",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -52,7 +52,7 @@
       "id": "HOIE",
       "text": "Home Office Interest",
       "category": "Information",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -84,7 +84,7 @@
       "id": "AVIS",
       "text": "ViSOR",
       "category": "Public Protection",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -92,7 +92,7 @@
       "id": "INVI",
       "text": "Victim Contact",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -108,7 +108,7 @@
       "id": "ADWC",
       "text": "Barred from working with children",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -140,7 +140,7 @@
       "id": "MSP",
       "text": "Modern Day Slavery - Perpetrator",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -156,7 +156,7 @@
       "id": "RSTO",
       "text": "Restraining Order",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -196,7 +196,7 @@
       "id": "SPO",
       "text": "Stalking Protection Order",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -212,7 +212,7 @@
       "id": "REG30",
       "text": "Domestic Abuse History",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 0,
       "active": true
     },
@@ -220,7 +220,7 @@
       "id": "RVLN",
       "text": "Vulnerable",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -244,7 +244,7 @@
       "id": "CUCK",
       "text": "Cuckooing - Potential Victim",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -260,7 +260,7 @@
       "id": "ADVV",
       "text": "Domestic Abuse Victim",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -268,7 +268,7 @@
       "id": "MSV",
       "text": "Modern Day Slavery - Victim",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -276,7 +276,7 @@
       "id": "STRG",
       "text": "Street Gangs",
       "category": "Public Protection",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -284,7 +284,7 @@
       "id": "REG26",
       "text": "Organised Crime",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -316,7 +316,7 @@
       "id": "ANSO",
       "text": "Non Registered Sex Offender",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": true
     },
@@ -324,7 +324,7 @@
       "id": "APPO",
       "text": "PPO",
       "category": "Public Protection",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -340,7 +340,7 @@
       "id": "RPIR",
       "text": "Public Interest Case",
       "category": "Public Protection",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -348,7 +348,7 @@
       "id": "DORIS",
       "text": "DoRIS (Disruption of Recorded Internal Secretors)",
       "category": "Alerts",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 0,
       "active": true
     },
@@ -356,7 +356,7 @@
       "id": "AMHL",
       "text": "Mental HeAt Last Terminationh Issues",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -468,7 +468,7 @@
       "id": "RMRH",
       "text": "Medium RoSH",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -492,7 +492,7 @@
       "id": "REG15",
       "text": "Risk to Known Adult",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -500,7 +500,7 @@
       "id": "REG22",
       "text": "Risk to \"Adult at Risk",
       "category": "Safeguarding",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -516,7 +516,7 @@
       "id": "REG17",
       "text": "Risk to Public",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -532,7 +532,7 @@
       "id": "REG16",
       "text": "Risk to Prisoner",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": true
     },
@@ -580,7 +580,7 @@
       "id": "REG27",
       "text": "Domestic Concerns",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 0,
       "active": false
     },
@@ -604,7 +604,7 @@
       "id": "REG21",
       "text": "Common Assessment Framework",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": false
     },
@@ -620,7 +620,7 @@
       "id": "RFNO",
       "text": "Foreign National",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -628,7 +628,7 @@
       "id": "FTRO",
       "text": "Foreign Travel Order",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": false
     },
@@ -636,7 +636,7 @@
       "id": "RHCV",
       "text": "Hate Crime Victim",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 12,
       "active": false
     },
@@ -652,7 +652,7 @@
       "id": "RKNF",
       "text": "Knife Crime",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -660,7 +660,7 @@
       "id": "RLAC",
       "text": "Looked After Child",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -676,7 +676,7 @@
       "id": "NUPW",
       "text": "Not eligible for UPW",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -692,7 +692,7 @@
       "id": "REG32",
       "text": "Restorative Justice",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": false
     },
@@ -716,7 +716,7 @@
       "id": "MSTC",
       "text": "Street Crime",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -764,7 +764,7 @@
       "id": "REG13",
       "text": "Violent Offender Order",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 0,
       "active": false
     },
@@ -796,7 +796,7 @@
       "id": "REG19",
       "text": "Victim No Contact",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": false
     },
@@ -804,7 +804,7 @@
       "id": "MIMA",
       "text": "Migrated ICMS Misc Contact Alert",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -820,7 +820,7 @@
       "id": "OMP2",
       "text": "OM Phase 2 Case",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -892,7 +892,7 @@
       "id": "RPRG",
       "text": "Pregnancy",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -916,7 +916,7 @@
       "id": "MILT",
       "text": "Armed Forces",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 12,
       "active": false
     },
@@ -932,7 +932,7 @@
       "id": "IWWO",
       "text": "Warrant without bail",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": false
     },
@@ -940,7 +940,7 @@
       "id": "IWWB",
       "text": "Warrant with bail",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 3,
       "active": false
     },
@@ -948,7 +948,7 @@
       "id": "OMP3",
       "text": "OM Phase 3 Case",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 6,
       "active": false
     },
@@ -956,7 +956,7 @@
       "id": "REG09",
       "text": "Client Notes",
       "category": "",
-      "colour": "orange",
+      "colour": "yellow",
       "reviewPeriod": 0,
       "active": false
     },

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,5 +1,7 @@
+const path = require('path')
 const cases = require('./cases')
 const fakeCases = require('./fake-cases')
+const helpers = require(path.join(__dirname, '../../lib/helpers.js'))
 
 const contactHistoryDefaults = (map, su) => {
   if (su.contactHistory) {
@@ -8,25 +10,8 @@ const contactHistoryDefaults = (map, su) => {
   return map
 }
 
-const highestRiskOfSeriousHarm = (su) => {
-  const riskValue = {
-    'Low': 0,
-    'Medium': 1,
-    'High': 2,
-    'Very high': 3
-  }
-
-  const compareRisk = (a, b) => {
-    if (riskValue[a.text] < riskValue[b.text]) { return -1 }
-    if (riskValue[a.text] > riskValue[b.text]) { return 1 }
-    return 0
-  }
-
-  su.riskOfSeriousHarmLevel = su.riskOfHarm.map(r => r.inCommunity).sort(compareRisk).pop()
-}
-
 const sessionCases = cases.concat(fakeCases(10))
-sessionCases.forEach(su => highestRiskOfSeriousHarm(su))
+sessionCases.forEach(su => helpers.highestRiskOfSeriousHarm(su))
 
 module.exports = {
   features: {

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -8,7 +8,25 @@ const contactHistoryDefaults = (map, su) => {
   return map
 }
 
+const highestRiskOfSeriousHarm = (su) => {
+  const riskValue = {
+    'Low': 0,
+    'Medium': 1,
+    'High': 2,
+    'Very high': 3
+  }
+
+  const compareRisk = (a, b) => {
+    if (riskValue[a.text] < riskValue[b.text]) { return -1 }
+    if (riskValue[a.text] > riskValue[b.text]) { return 1 }
+    return 0
+  }
+
+  su.riskOfSeriousHarmLevel = su.riskOfHarm.map(r => r.inCommunity).sort(compareRisk).pop()
+}
+
 const sessionCases = cases.concat(fakeCases(10))
+sessionCases.forEach(su => highestRiskOfSeriousHarm(su))
 
 module.exports = {
   features: {

--- a/app/routes/cases.js
+++ b/app/routes/cases.js
@@ -86,8 +86,8 @@ module.exports = router => {
   })
 
   router.all('/cases/:CRN/flag/:flagSlug', function (req, res) {
-    const riskBadges = res.locals.case.riskBadges
-    const flag = riskBadges.find(flag => {
+    const riskFlags = res.locals.case.riskFlags
+    const flag = riskFlags.find(flag => {
       return slugify(flag.text, { lower: true }) === req.params.flagSlug
     })
     res.locals.flag = flag

--- a/app/views/_components/risk-flag/template.njk
+++ b/app/views/_components/risk-flag/template.njk
@@ -1,10 +1,6 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% set flag = params.flag %}
-{% if flag.rosh %}
-  {% set flagClass = 'govuk-tag--' + flag.colour if flag.colour else flag.class %}
-{% else %}
-  {% set flagClass = 'govuk-tag--grey' %}
-{% endif %}
+{% set flagClass = 'govuk-tag--' + flag.colour if flag.colour else flag.class %}
 
 {% set flagHtml %}
   {% if flag.rosh %}

--- a/app/views/_components/risk-flag/template.njk
+++ b/app/views/_components/risk-flag/template.njk
@@ -1,6 +1,10 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 {% set flag = params.flag %}
-{% set flagClass = 'govuk-tag--' + flag.colour if flag.colour else flag.class %}
+{% if flag.rosh %}
+  {% set flagClass = 'govuk-tag--' + flag.colour if flag.colour else flag.class %}
+{% else %}
+  {% set flagClass = 'govuk-tag--grey' %}
+{% endif %}
 
 {% set flagHtml %}
   {% if flag.rosh %}

--- a/app/views/_components/risk-flag/template.njk
+++ b/app/views/_components/risk-flag/template.njk
@@ -3,8 +3,8 @@
 {% set flagClass = 'govuk-tag--' + flag.colour if flag.colour else flag.class %}
 
 {% set flagHtml %}
-  {% if flag.rosh %}
-    <a href="#">{{ flag.text }}</a>
+  {% if params.rosh %}
+    <a href="#">{{ flag.text }} risk of harm</a>
   {% else %}
     <a href="/cases/{{ params.CRN }}/flag/{{ flag.text | toSlug }}">{{ flag.text }}</a>
   {% endif %}

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -8,12 +8,12 @@
 </h1>
 
 <p>
+  {{ appRiskFlag({ flag: case.riskOfSeriousHarmLevel, CRN: CRN, rosh: true }) }}
   {% if failureToComplyCount > 0 %}
     <strong class="govuk-tag govuk-tag--link govuk-!-margin-right-1 govuk-tag--red">
       <a href="/cases/{{ CRN }}/compliance">Non-compliance</a>
     </strong>
   {% endif %}
-  {{ appRiskFlag({ flag: case.riskOfSeriousHarmLevel, CRN: CRN, rosh: true }) }}
   {% for flag in case.riskFlags %}
     {{ appRiskFlag({ flag: flag, CRN: CRN }) }}
   {% endfor %}

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -13,7 +13,7 @@
       <a href="/cases/{{ CRN }}/compliance">Non-compliance</a>
     </strong>
   {% endif %}
-  {% for flag in case.riskBadges %}
+  {% for flag in case.riskFlags %}
     {{ appRiskFlag({ flag: flag, CRN: CRN }) }}
   {% endfor %}
 </p>

--- a/app/views/case/_case-service-user-banner.html
+++ b/app/views/case/_case-service-user-banner.html
@@ -13,6 +13,7 @@
       <a href="/cases/{{ CRN }}/compliance">Non-compliance</a>
     </strong>
   {% endif %}
+  {{ appRiskFlag({ flag: case.riskOfSeriousHarmLevel, CRN: CRN, rosh: true }) }}
   {% for flag in case.riskFlags %}
     {{ appRiskFlag({ flag: flag, CRN: CRN }) }}
   {% endfor %}

--- a/app/views/case/flag.html
+++ b/app/views/case/flag.html
@@ -112,11 +112,6 @@
 
     <p>To identify offenders convicted under the Sexual Offences Act 2003 and therefore subject to the notification period and requirements of the Sex Offender Register.</p>
 
-    <h3 class="govuk-heading-m">Category</h3>
-
-    <p>{{ govukTag({ text: 'Public protection', classes: 'govuk-tag--purple' }) }}</p>
-    <p><a href="#">About this category</a></p>
-
     <h3 class="govuk-heading-m">Suggested review frequency</h3>
 
     <p>Every 3 months</p>

--- a/app/views/case/flags.html
+++ b/app/views/case/flags.html
@@ -39,7 +39,7 @@
   {{ govukButton({
     text: 'Add flag',
     href: '#',
-    classes: 'govuk-button'
+    classes: 'govuk-button govuk-!-margin-bottom-2'
   }) }}
 </p>
 
@@ -83,10 +83,11 @@
     ]
   }) }}
 {% endset %}
-{{ govukDetails({
+
+<!-- {{ govukDetails({
   summaryText: "Risk flag categories",
   html: categoryHtml
-}) }}
+}) }} -->
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -109,7 +110,7 @@
   </tbody>
 </table>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">Historic flags</h2>
+<h2 class="govuk-heading-m govuk-!-font-size-27">Old flags</h2>
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
@@ -120,22 +121,22 @@
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Weapons</a>', classes: 'govuk-tag--link govuk-tag--pink' }) }}</td>
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Weapons</a>', classes: 'govuk-tag--link govuk-tag--grey' }) }}</td>
       <td class="govuk-table__cell app-flags-table-cell">Caught carrying a knife</td>
       <td class="govuk-table__cell app-flags-table-cell">Today</td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Domestic abuse</a>', classes: 'govuk-tag--link govuk-tag--purple' }) }}</td>
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Domestic abuse</a>', classes: 'govuk-tag--link govuk-tag--grey' }) }}</td>
       <td class="govuk-table__cell app-flags-table-cell">Against ex-partner</td>
       <td class="govuk-table__cell app-flags-table-cell">Today</td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Victim</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Victim</a>', classes: 'govuk-tag--link govuk-tag--grey' }) }}</td>
       <td class="govuk-table__cell app-flags-table-cell">Level 2, Category 3</td>
       <td class="govuk-table__cell app-flags-table-cell">2 Jan 2021</td>
     </tr>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Vulnerable</a>', classes: 'govuk-tag--link govuk-tag--turquoise' }) }}</td>
+      <td class="govuk-table__cell">{{ govukTag({ html: '<a href="#">Vulnerable</a>', classes: 'govuk-tag--link govuk-tag--grey' }) }}</td>
       <td class="govuk-table__cell app-flags-table-cell">Level 2, Category 3</td>
       <td class="govuk-table__cell app-flags-table-cell">10 Nov 2020</td>
     </tr>

--- a/app/views/case/flags.html
+++ b/app/views/case/flags.html
@@ -97,7 +97,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    {% for flag in case.riskBadges %}
+    {% for flag in case.riskFlags %}
       {% if not flag.rosh %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">{{ appRiskFlag({ flag: flag, CRN: CRN }) }}</td>

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -73,7 +73,7 @@
     <p><a href="/cases/{{ CRN }}/flags">Add, review or remove flags</a></p>
 
     <dl class="govuk-summary-list govuk-summary-list--no-border">
-      {% for flag in case.riskBadges %}
+      {% for flag in case.riskFlags %}
         {% if not flag.rosh %}
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const contactTypes = require(path.join(__dirname, '../app/data/reference/contact-types.json'))
+const riskFlags = require(path.join(__dirname, '../app/data/reference/risk-flags.json'))
 const { Locations } = require(path.join(__dirname, '../app/models/locations.js'))
 const { ArrangedSession } = require(path.join(__dirname, '../app/models/arranged-session.js'))
 const { Outcomes } = require(path.join(__dirname, '../app/models/outcomes.js'))
@@ -223,6 +224,10 @@ exports.userName = (data) => {
 
 exports.replaceDefaultUserWithSignedInUser = (defaultUser, data) => {
   return defaultUser === 'Mark Berridge' ? exports.userName(data) : defaultUser
+}
+
+exports.getFlag = (flagId) => {
+  return riskFlags.flags.find(flag => flag.id === flagId)
 }
 
 exports.addHelpers = function (env) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -230,6 +230,23 @@ exports.getFlag = (flagId) => {
   return riskFlags.flags.find(flag => flag.id === flagId)
 }
 
+exports.highestRiskOfSeriousHarm = (suCase) => {
+  const riskValue = {
+    'Low': 0,
+    'Medium': 1,
+    'High': 2,
+    'Very high': 3
+  }
+
+  const compareRisk = (a, b) => {
+    if (riskValue[a.text] < riskValue[b.text]) { return -1 }
+    if (riskValue[a.text] > riskValue[b.text]) { return 1 }
+    return 0
+  }
+
+  suCase.riskOfSeriousHarmLevel = suCase.riskOfHarm.map(r => r.inCommunity).sort(compareRisk).pop()
+}
+
 exports.addHelpers = function (env) {
   env.addGlobal('progressPercentage', exports.progressPercentage)
 


### PR DESCRIPTION
Refactor risk flags so that:

- cases do not repeat risk flag text, instead they use the reference data
- risk of serious harm level is calculated based on the highest risk in the community data (as it is on live)
- use built in colours from Delius rather than our custom category colours
- remove all references to categories
- rename riskBadges to riskFlags
- use yellow not orange for risk flags to improve differentiation with red

> Remove categories, stick with alphabetical list
> Whilst 30% of participants said they were useful, and 46% of said they were “quite useful” there seems to be very little consensus on how to re categorise or improve the categories going forward. Suggest simplifying things for now by removing the categories and keep the flags in alphabetical order

https://docs.google.com/presentation/d/1r-ncykED4B2w0VVZ8h6T8_alg21MN0sOM4c0qWjHnkQ/edit#slide=id.ge2888fffa3_1_12

![Screen Shot 2021-07-05 at 12 36 22](https://user-images.githubusercontent.com/319055/124465712-a303e200-dd8d-11eb-8a87-1d3fff3d2b27.png)

![Screen Shot 2021-07-05 at 12 33 36](https://user-images.githubusercontent.com/319055/124465454-5a4c2900-dd8d-11eb-9b91-11edcfa05d11.png)

![Screen Shot 2021-07-05 at 12 34 16](https://user-images.githubusercontent.com/319055/124465456-5b7d5600-dd8d-11eb-9d67-47ff514c8f3d.png)
