### PR TITLE
Remove 'In custody' risk column from overview page

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -226,19 +226,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Children',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -248,10 +240,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -259,10 +247,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -270,19 +254,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Prisoners',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -798,10 +774,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -809,10 +781,6 @@ module.exports = [
         'inCommunity': {
           text: 'High',
           class: 'red'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -820,10 +788,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -831,10 +795,6 @@ module.exports = [
         'inCommunity': {
           text: 'High',
           class: 'red'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -842,10 +802,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -853,10 +809,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       }
     ],
@@ -1096,19 +1048,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Children',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -1118,19 +1062,11 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Known adult',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -1140,19 +1076,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Prisoners',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -1344,10 +1272,6 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -1355,10 +1279,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -1366,10 +1286,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -1377,10 +1293,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -1388,19 +1300,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Prisoners',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -1781,19 +1685,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Children',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }
@@ -1803,10 +1699,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -1814,10 +1706,6 @@ module.exports = [
         'inCommunity': {
           text: 'Medium',
           class: 'orange'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
@@ -1825,19 +1713,11 @@ module.exports = [
         'inCommunity': {
           text: 'Low',
           class: 'green'
-        },
-        'inCustody': {
-          text: 'Low',
-          class: 'green'
         }
       },
       {
         'riskTo': 'Prisoners',
         'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        },
-        'inCustody': {
           text: 'Low',
           class: 'green'
         }

--- a/app/data/generators/risk.js
+++ b/app/data/generators/risk.js
@@ -12,33 +12,27 @@ module.exports = (faker, generatorHelpers) => {
   const riskOfHarm = [
     {
       'riskTo': 'Themselves',
-      'inCommunity': faker.random.arrayElement([high, medium, low]),
-      'inCustody': faker.random.arrayElement([high, medium, low])
+      'inCommunity': faker.random.arrayElement([high, medium, low])
     },
     {
       'riskTo': 'Children',
-      'inCommunity': faker.random.arrayElement([high, medium, low]),
-      'inCustody': faker.random.arrayElement([high, medium, low])
+      'inCommunity': faker.random.arrayElement([high, medium, low])
     },
     {
       'riskTo': 'Public',
-      'inCommunity': faker.random.arrayElement([high, medium, low]),
-      'inCustody': faker.random.arrayElement([high, medium, low])
+      'inCommunity': faker.random.arrayElement([high, medium, low])
     },
     {
       'riskTo': 'Known adult',
-      'inCommunity': faker.random.arrayElement([high, medium, low]),
-      'inCustody': faker.random.arrayElement([high, medium, low])
+      'inCommunity': faker.random.arrayElement([high, medium, low])
     },
     {
       'riskTo': 'Staff',
-      'inCommunity': faker.random.arrayElement([high, medium, low]),
-      'inCustody': faker.random.arrayElement([high, medium, low])
+      'inCommunity': faker.random.arrayElement([high, medium, low])
     },
     {
       'riskTo': 'Prisoners',
-      'inCommunity': faker.random.arrayElement([high, medium, low]),
-      'inCustody': faker.random.arrayElement([high, medium, low])
+      'inCommunity': faker.random.arrayElement([high, medium, low])
     }
   ]
 

--- a/app/views/case/index.html
+++ b/app/views/case/index.html
@@ -104,7 +104,6 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header">Risk to</th>
           <th class="govuk-table__header">In community</th>
-          <th class="govuk-table__header">In custody</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -113,9 +112,6 @@
           <td class="govuk-table__cell">{{ risks.riskTo }}</td>
           <td class="govuk-table__cell">
             <span class="govuk-tag govuk-tag--{{ risks.inCommunity.class }}">{{ risks.inCommunity.text }}</span>
-          </td>
-          <td class="govuk-table__cell">
-            <span class="govuk-tag govuk-tag--{{ risks.inCustody.class }}">{{ risks.inCustody.text }}</span>
           </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
The service is dealing with community cases initially so custody risk isn't
relevant for those.

![image](https://user-images.githubusercontent.com/23801/124152566-903a9600-da8b-11eb-9452-8306b9875d6d.png)
