### PR TITLE
Remove 'To prisoners' row in the RoSH risk table

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -296,13 +296,6 @@ module.exports = [
           text: 'Low',
           class: 'green'
         }
-      },
-      {
-        'riskTo': 'Prisoners',
-        'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        }
       }
     ],
     'criminogenicNeeds': [
@@ -844,13 +837,6 @@ module.exports = [
           text: 'Medium',
           class: 'orange'
         }
-      },
-      {
-        'riskTo': 'Prisoners',
-        'inCommunity': {
-          text: 'Medium',
-          class: 'orange'
-        }
       }
     ],
     'criminogenicNeeds': [
@@ -1122,13 +1108,6 @@ module.exports = [
           text: 'Low',
           class: 'green'
         }
-      },
-      {
-        'riskTo': 'Prisoners',
-        'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        }
       }
     ],
     'criminogenicNeeds': [
@@ -1342,13 +1321,6 @@ module.exports = [
       },
       {
         'riskTo': 'Staff',
-        'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        }
-      },
-      {
-        'riskTo': 'Prisoners',
         'inCommunity': {
           text: 'Low',
           class: 'green'
@@ -1754,13 +1726,6 @@ module.exports = [
       },
       {
         'riskTo': 'Staff',
-        'inCommunity': {
-          text: 'Low',
-          class: 'green'
-        }
-      },
-      {
-        'riskTo': 'Prisoners',
         'inCommunity': {
           text: 'Low',
           class: 'green'

--- a/app/data/generators/risk.js
+++ b/app/data/generators/risk.js
@@ -29,10 +29,6 @@ module.exports = (faker, generatorHelpers) => {
     {
       'riskTo': 'Staff',
       'inCommunity': faker.random.arrayElement([high, medium, low])
-    },
-    {
-      'riskTo': 'Prisoners',
-      'inCommunity': faker.random.arrayElement([high, medium, low])
     }
   ]
 


### PR DESCRIPTION
This data isn't relevant (and doesn't exist) for community cases.